### PR TITLE
workflow: reusable workflows should be referenced at the top-level

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,4 @@ jobs:
   publish:
     permissions:
       id-token: write # Required for authentication using OIDC
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish to pub.dev
-        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## 🔑 Change Log

1. reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps
