### PR TITLE
docs: add design discussion issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/design_discussion.yml
@@ -8,8 +8,8 @@ body:
     attributes:
       label: Topic
       placeholder: Describe the main question or design concern.
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: considerations
     attributes:


### PR DESCRIPTION
### Changes

- Add .github/ISSUE_TEMPLATE/design_discussion.yml to standardize architecture and design conversations.
- Configure the template with a default [Design] title prefix and discussion label.
- Define structured input fields for "Topic" (required) and "Considerations" to guide the discussion format.