### PR TITLE
fix: `dart analyze` warnings and lint issues

### DIFF
--- a/lib/src/cjk_utils.dart
+++ b/lib/src/cjk_utils.dart
@@ -1,5 +1,6 @@
 /// Utility functions for CJK (Chinese, Japanese, Korean) character detection
 /// and typography transformations.
+library cjk_utils;
 
 /// Returns `true` if [codeUnit] falls within a CJK character range.
 ///

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -140,7 +140,6 @@ class _Scanner {
     // Check for special tags that capture content (script, style, pre, code, kbd, math)
     // Only if it's an opening tag
     if (!isClosing && _isSpecialTag(tagName)) {
-      final contentStart = _index;
       // Smart search for closing tag allowing whitespace: </tagName\s*>
       final closingPattern = RegExp('</$tagName\\s*>', caseSensitive: false);
       // We search in the substring starting from current index

--- a/test/smartypants_html_test.dart
+++ b/test/smartypants_html_test.dart
@@ -44,9 +44,9 @@ void main() {
 
     test('should ignore quotes inside HTML attributes', () {
       String input =
-          '<img src="test.png" alt="\"Quoted\" Alt" title=\'Title\'> "Text"';
+          '<img src="test.png" alt=""Quoted" Alt" title=\'Title\'> "Text"';
       String expected =
-          '<img src="test.png" alt="\"Quoted\" Alt" title=\'Title\'> “Text”';
+          '<img src="test.png" alt=""Quoted" Alt" title=\'Title\'> “Text”';
       expect(SmartyPants.formatText(input), expected);
     });
 
@@ -79,9 +79,9 @@ void main() {
 
     test('should ignore symbols inside HTML attributes', () {
       String input =
-          '<img src="test.png" alt="\"Quoted\" -- Alt" title=\'Title ...\'> "Text" --';
+          '<img src="test.png" alt=""Quoted" -- Alt" title=\'Title ...\'> "Text" --';
       String expected =
-          '<img src="test.png" alt="\"Quoted\" -- Alt" title=\'Title ...\'> “Text” –';
+          '<img src="test.png" alt=""Quoted" -- Alt" title=\'Title ...\'> “Text” –';
       expect(SmartyPants.formatText(input), expected);
     });
 


### PR DESCRIPTION
## Changes


- `lib/src/tokenizer.dart`
    : Removed the unused local variable contentStart in _Scanner.scanTag.
- `lib/src/cjk_utils.dart`
    : Added a named library directive to fix dangling doc comments and ensure compatibility with older Dart SDK versions.
- `test/smartypants_html_test.dart`
    : Removed unnecessary string escapes (e.g., \" inside single-quoted strings) that were flagging lint info.

