### PR TITLE
ci: add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Summary
+
+<!-- What does this PR change? Keep it short and concrete. -->
+
+## Background / Motivation
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Related Issues
+
+<!-- Link issues/discussions. Examples: Closes #123, Related #456 -->
+
+- Closes #
+- Related #
+
+## Changes
+
+<!-- List the main changes (implementation + behavior). -->
+
+- ...
+
+## Test Plan
+
+<!-- What did you run/do to verify this? Include commands and environments when helpful. -->
+
+- Commands run:
+    - `dart test`
+- Notes:
+    - ...
+
+## Documentation (If Needed)
+
+<!-- README updates, Dartdoc changes, etc. -->
+
+- ...
+
+## Breaking Change (If Any)
+
+<!-- If this is breaking, describe impact and migration steps. -->
+
+- Migration notes:
+    - ...
+


### PR DESCRIPTION
## Summary
Adds a standard GitHub pull request template to improve review consistency and ensure key context is included in every PR.

## Background / Motivation
Issue templates are already in place, but PR descriptions vary a lot without a template. This change standardizes PR submissions so reviewers consistently get the “why”, issue links, test coverage, doc updates, and breaking-change notes.

## Changes
- Added `.github/PULL_REQUEST_TEMPLATE.md` with sections for:
  - Background / motivation
  - Related issues
  - Test plan
  - Documentation updates (README/Dartdoc)
  - Breaking change + migration notes
  - Reviewer notes
- Included a checklist to encourage consistent PR quality.

## Test Plan
- N/A (repo metadata / template-only change)

## Documentation (If Needed)
- N/A

## Breaking Change (If Any)
- None

