### PR TITLE
chore: update release-please config to include tag options

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,9 @@
       "release-type": "dart",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "include-v-in-tag": false,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Add `include-v-in-tag` and `include-component-in-tag` options to `release-please-config.json` to control the generated git tag format.

## Background / Motivation

Without these options explicitly set, release-please may generate tags with a `v` prefix (e.g. `v0.1.0`) or a component prefix, which is inconsistent with the intended plain semver format (e.g. `0.1.0`).

## Related Issues

- Closes #
- Related #

## Changes

- `release-please-config.json` — add `"include-v-in-tag": false` and `"include-component-in-tag": false`

## Test Plan

- Commands run:
    - `dart test`
    - `cd example && flutter test`
- Notes:
    - ...

## Documentation (If Needed)


## Breaking Change (If Any)

- None
