### PR TITLE
refactor: pre-compile regex patterns and add benchmark suite

### DIFF
--- a/benchmark/smartypants_benchmark.dart
+++ b/benchmark/smartypants_benchmark.dart
@@ -1,0 +1,355 @@
+import 'package:smartypants/smartypants.dart';
+
+void main() {
+  runBenchmark('Small input', _smallInput, iterations: 1000);
+  runBenchmark('Large input', _largeInput, iterations: 1000);
+  runBenchmark(
+    'CJK-heavy',
+    _cjkInput,
+    iterations: 1000,
+    config: SmartyPantsConfig(locale: SmartyPantsLocale.zhHant),
+  );
+  runBenchmark('HTML-heavy', _htmlInput, iterations: 1000);
+}
+
+void runBenchmark(
+  String name,
+  String input, {
+  int iterations = 1000,
+  SmartyPantsConfig? config,
+}) {
+  // warm up
+  for (var i = 0; i < 10; i++) {
+    SmartyPants.formatText(input, config: config);
+  }
+
+  final stopwatch = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    SmartyPants.formatText(input, config: config);
+  }
+  stopwatch.stop();
+
+  final totalMs = stopwatch.elapsedMilliseconds;
+  final avgUs = stopwatch.elapsedMicroseconds / iterations;
+  print(
+    '[$name] ${iterations}x: ${totalMs}ms total, '
+    '${avgUs.toStringAsFixed(1)}µs/call '
+    '(input: ${input.length} chars)',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark inputs
+// ---------------------------------------------------------------------------
+
+const _smallInput = 'She said "Hello, world!" -- it\'s a great day... '
+    'and the result is >= 10 or <= 5, so -> proceed!';
+
+const _largeInput = '''
+Chapter 1: "The Beginning"
+
+It was the best of times---it was the worst of times. She said, "We need to
+talk," and he replied, "I'm listening." The temperature was >= 30 degrees,
+yet it felt <= 20. They walked -> the horizon and back <-> the shore.
+
+Paragraph 2: Contractions and Dashes
+
+It's amazing how we're able to adapt. They've seen it all before---the
+highs and the lows. "Don't give up," he whispered. The margin was != 0,
+which meant the formula was >= the threshold...
+
+Paragraph 3: More Quotations
+
+"Every great dream begins with a dreamer," she reminded him. "Always
+remember, you have within you the strength, the patience, and the passion
+to reach for the stars." He nodded -- it made sense.
+
+Paragraph 4: Technical Notes
+
+The algorithm runs in O(n log n) time. When x >= y and z <= w, the output
+is != null. Use the arrow -> to indicate direction, or <-> for bidirectional
+flow. The implication => holds when both sides are true...
+
+Paragraph 5: Narrative
+
+"Why do we fall?" asked the mentor. "So we can learn to pick ourselves up,"
+answered the student. It's a lesson we've all heard---yet it's one we keep
+needing to relearn. They've been at it for hours -- no sign of stopping...
+
+Paragraph 6: More Contractions
+
+We're not done yet. It's only the beginning. They've promised to return,
+and we're holding them to it. "Don't worry," said the guide. "We'll make
+it." The path ahead was != clear, but the direction was -> forward.
+
+Paragraph 7: Ellipsis and Dashes
+
+She paused... gathered her thoughts... and spoke. "This is it---our moment."
+The crowd fell silent. Then -- slowly -- the applause began. "Is this really
+happening?" she asked. "Yes," came the reply, "it's real..."
+
+Paragraph 8: Numbers and Symbols
+
+The value must be >= 100 and <= 200. Any reading != 150 triggers an alert.
+The pointer moves -> right or <- left depending on input. Bidirectional:
+<->. The implication => is strict here. Precision matters...
+
+Paragraph 9: Dialogue Heavy
+
+"Come in," said the host. "We've been expecting you." The visitor replied,
+"I'm sorry I'm late." "Don't apologize---you're right on time," the host
+insisted. "It's been a long road," the visitor admitted. "Indeed it has..."
+
+Paragraph 10: Closing
+
+And so they parted---each carrying a piece of the other's story. "We'll
+meet again," she said. "I'm sure of it." He smiled. "It's not goodbye---
+it's see you later." The door closed. The chapter ended... but the story?
+The story was just beginning. >= all expectations, and <= any fear.
+
+Paragraph 11: Repeated Themes
+
+"Every ending is a new beginning," she wrote in her journal. It's a cliche,
+but we've all felt its truth. They've documented it thoroughly---page after
+page of observations. "Don't ignore the data," warned the analyst. The
+trend was != random; it was -> deliberate...
+
+Paragraph 12: Final Thoughts
+
+In conclusion, we're reminded that it's not about where we've been, but
+where we're going. "Keep moving," urged the coach. "We've got this." The
+finish line was >= 10 kilometers away, but the spirit was <= daunted. One
+step -> another. That's all it takes. And perhaps... that's enough.
+
+Chapter 2: "The Middle Ground"
+
+The second chapter opened with a question: "What's the point?" He wasn't
+sure---nobody was. It's a feeling we've all had at some point. The numbers
+didn't lie: >= 60% of respondents said they'd felt it too. The arrow of
+time moves -> forward, never <-> back. That's just how it works...
+
+Paragraph 14: Debate
+
+"You're wrong," she said flatly. "I'm not---and here's why." He laid out
+his argument point by point. It wasn't != the truth; it was just a different
+angle. "Don't dismiss it," she warned. "We've been down that road before."
+The margin of error was <= 2%, which meant the result was >= reliable.
+
+Paragraph 15: The Long Road
+
+They'd been walking for what felt like forever---hours turning into days.
+"I can't go on," he said. "You can't not go on," she replied. It's a
+paradox we've all faced. The distance was >= 50 miles, but the spirit was
+<= exhausted. One step -> the next. That's the only formula that works...
+
+Paragraph 16: Reflection
+
+Looking back, it's clear that we've grown. "Don't underestimate progress,"
+said the philosopher. "We've come further than we think." The arc of change
+moves -> improvement, not <-> stagnation. The delta was != zero; it was
+measurable, >= significant. She smiled. "I'm glad we didn't give up..."
+
+Paragraph 17: The Argument
+
+"It's not that simple," he insisted. "Yes it is---you're overthinking it,"
+she shot back. They'd been at this for hours. The truth was somewhere >=
+the obvious and <= the obscure. "Don't lose sight of what we're doing here,"
+he urged. "We'll find it," she said. "We've always found it before..."
+
+Paragraph 18: Night Thoughts
+
+In the quiet of the night, she thought: "What's next?" The stars were !=
+answers, but they were something. The telescope pointed -> a distant galaxy,
+and she wondered <-> the vastness. "It's humbling," she wrote. "We're so
+small---and yet we've built all this." The cosmos was >= indifferent, but
+it was also <= hostile. Perhaps that was enough...
+
+Paragraph 19: Morning
+
+"Good morning," he said. "I'm ready." The day stretched -> possibility,
+vast and != predictable. They'd packed what they needed---no more, no less.
+"Don't overdo it," she reminded him. "We've got a long way to go." The
+forecast was >= sunny with <= 20% chance of rain. A good day to move...
+
+Paragraph 20: The Decision
+
+It came down to this: "Do we go or do we stay?" He thought... she thought...
+They'd been over it before---the pros, the cons. The expected value was >=
+the risk. "I'm in," she said. "Me too," he agreed. And just like that, the
+decision was made. Not with fanfare---just two words. -> Forward. That's all.
+
+Paragraph 21: Aftermath
+
+"I can't believe we did it," he said. "I can," she replied. "We've always
+been capable of more than we thought." The results were != expected---they
+were better. >= every projection, and <= any downside. "Don't let this go
+to your head," warned the advisor. Too late---it already had. And that's
+fine. It's earned. We'll take it.
+
+Paragraph 22: Looking Forward
+
+The road ahead was != clear, but it was -> visible. "We've done the hard
+part," she said. "Haven't we?" He shrugged. "I'm not sure there is a hard
+part---it's all hard." She laughed. "Fair point." They walked on. The sun
+was >= warm and the breeze was <= cold. Perfect conditions for what comes
+next. Whatever that is. Wherever that leads. Onward...
+
+Paragraph 23: The Last Mile
+
+"We're almost there," she said. The finish line was -> near, >= reachable,
+<= a mile away. "Don't jinx it," he said. "I'm not---I'm just stating the
+facts." It's a distinction we've all had to make at one point or another.
+The data was != wrong. The trend was => positive. They'd made it. Almost.
+
+Paragraph 24: The End of the Middle
+
+And so the middle came to a close---not with a bang, not with a whisper,
+but with a steady, deliberate step -> the next chapter. "I'm proud of us,"
+she said. "We've earned this." He nodded. "It's been a long road." "It has."
+They paused... looked back... and looked forward. Then walked on. >= hope,
+<= doubt. That's the best any of us can do. And it's enough. It really is.
+''';
+
+const _cjkInput = '''
+<<書籍>>의 세계에 오신 것을 환영합니다。。。이 책은 日本語와 中文를 함께 다룹니다。
+<<文學>>은 인류의 유산입니다。。。我們一起來學習吧！<<知識>>是無價的。
+日本の文化は豊かです。<<芸術>>の世界へようこそ。。。
+한국어로도 읽을 수 있어요。<<언어>>는 소통의 도구입니다。。。
+这本书介绍了<<历史>>的重要性。文化交流是美好的。。。
+
+第一章：<<文化의 만남>>
+
+동아시아의 문화는 오랜 역사를 가지고 있습니다。한국、중국、일본은 서로 깊은 영향을 주고받았습니다。
+<<三國志>>는 중국의 역사를 담은 위대한 작품입니다。。。이를 통해 우리는 역사의 흐름을 이해할 수 있습니다。
+日本では、<<源氏物語>>が世界最古の長編小説とされています。紫式部が書いたこの作品は、平安時代の宮廷生活を描いています。。。
+중국의 <<紅樓夢>>은 청나라 시대의 걸작으로、가족의 흥망성쇠를 다루고 있습니다。
+韓国の<<춘향전>>は、신분을 초월한 사랑 이야기로 오늘날에도 사랑받고 있습니다。。。
+
+第二章：<<언어와 문자>>
+
+한자(漢字)는 동아시아 문명의 공통 유산입니다。한국에서는 한글과 함께 사용되고、일본에서는 히라가나、가타카나와 함께 쓰입니다。
+<<言語학>>의 관점에서 보면、이 세 언어는 서로 다른 어족에 속하지만 많은 한자어를 공유합니다。。。
+中文的書寫系統有繁體字和簡體字兩種。<<文字改革>>是二十世紀中國的重大事件。
+日本語には、平仮名、片仮名、漢字という三つの文字システムがあります。<<万葉集>>は最古の和歌集です。。。
+한국의 세종대왕은 <<훈민정음>>을 창제하여 백성들이 쉽게 글을 읽고 쓸 수 있도록 하였습니다。
+
+第三章：<<현대 사회와 전통>>
+
+현대 사회에서도 전통 문화는 중요한 역할을 합니다。<<전통 예술>>은 현대적으로 재해석되어 새로운 생명을 얻고 있습니다。。。
+中國的傳統節日如春節、中秋節，在現代社會依然深受重視。<<節日文化>>反映了民族的精神和價值觀。
+日本の伝統芸能である<<歌舞伎>>や<<能楽>>は、ユネスコの無形文化遺産に登録されています。。。
+한국의 <<판소리>>와 <<탈춤>>도 세계가 인정한 무형문화유산입니다。전통은 과거가 아닌 살아있는 현재입니다。
+
+第四章：<<음식 문화>>
+
+음식은 문화의 중요한 부분입니다。<<한식>>은 발효 음식으로 유명하며、특히 김치는 세계적으로 알려져 있습니다。。。
+中國料理は世界で最も多様な料理の一つです。<<四川料理>>の辛さ、<<広東料理>>の繊細さ、地域によって全く異なります。
+日本の<<和食>>は、2013年にユネスコの無形文化遺産に登録されました。一汁三菜という基本形式が特徴です。。。
+세 나라 모두 쌀을 주식으로 하지만、조리 방법과 식문화는 매우 다릅니다。<<음식>>을 통해 문화를 이해할 수 있습니다。
+''';
+
+const _htmlInput = '''
+<article>
+  <h1>"Getting Started" Guide</h1>
+  <p>She said "Hello, world!" -- it's a great way to begin. The result is
+  <code>x >= 10</code> or <code>y <= 5</code>, so we proceed accordingly.</p>
+
+  <h2>Section 1: "Core Concepts"</h2>
+  <p>The arrow <strong>-></strong> shows direction, and <strong><-></strong>
+  means bidirectional flow. Don't forget: <code>a != b</code> implies the
+  values differ. The threshold is >= 100 and the limit is <= 500.</p>
+
+  <pre>
+    // Don't modify "this" code block
+    if (x >= threshold && y <= limit) {
+      result = x -> next;  // forward only
+    }
+    // a != b means they're different...
+  </pre>
+
+  <h2>Section 2: "Advanced Usage"</h2>
+  <p>"Keep going," she said --- "we're almost there..." The implementation
+  is straightforward once you've understood the basics. It's not as hard
+  as it looks---trust the process.</p>
+
+  <blockquote>
+    <p>"Every tool has its purpose," wrote the engineer. "Don't use a hammer
+    when you need a scalpel." The precision required was >= 0.001mm, while
+    the tolerance was <= 0.005mm. That's the difference between success and
+    failure...</p>
+  </blockquote>
+
+  <h2>Section 3: "Configuration"</h2>
+  <p>The config file accepts values >= 0 and <= 1000. Any value != the
+  default triggers a warning. Use the <code>-></code> operator to chain
+  transformations, or <code><-></code> for reversible ones.</p>
+
+  <ul>
+    <li>Option A: "Fast mode" -- processes <= 100 items per second</li>
+    <li>Option B: "Precise mode" -- accuracy >= 99.9%</li>
+    <li>Option C: "Balanced mode" -- it's the best of both worlds...</li>
+  </ul>
+
+  <h2>Section 4: "Troubleshooting"</h2>
+  <p>If you're seeing errors, don't panic. "It's probably a config issue,"
+  said the support team. Check that your values are != null and that the
+  path points -> the correct directory. The log file is usually located
+  <code><-></code> the main config.</p>
+
+  <pre>
+    ERROR: "Connection refused" -- check your settings
+    INFO:  threshold >= 10 required
+    WARN:  value != expected (got <= 5, need >= 10)
+  </pre>
+
+  <p>We've seen this before---it's a known issue. Don't worry: it's fixable.
+  The solution is -> straightforward once you've identified the root cause.
+  "Take it step by step," advised the documentation. That's the key...</p>
+
+  <h2>Section 5: "Best Practices"</h2>
+  <p>"Always test your changes," urged the senior developer. "We've had too
+  many incidents---let's not repeat them." The test coverage should be
+  >= 80% and the build time <= 5 minutes. It's not just a suggestion---
+  it's a requirement. Don't skip it.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>"Metric"</th>
+        <th>"Target"</th>
+        <th>"Acceptable"</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Coverage</td>
+        <td>>= 90%</td>
+        <td>>= 80%</td>
+      </tr>
+      <tr>
+        <td>Build time</td>
+        <td><= 3 min</td>
+        <td><= 5 min</td>
+      </tr>
+      <tr>
+        <td>Response time</td>
+        <td><= 100ms</td>
+        <td><= 500ms</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Section 6: "Conclusion"</h2>
+  <p>In conclusion, it's been a great journey. We've covered a lot of
+  ground---from basics to advanced topics. "I'm impressed," said the
+  reviewer. "You've done it justice." The final score was >= expectations,
+  and the effort was <= daunting in hindsight. One step -> the next.
+  That's all it ever takes...</p>
+
+  <footer>
+    <p><em>"The best documentation is the one that doesn't need to exist,"
+    -- someone wise once said. We've tried our best. It's not perfect---
+    nothing is. But it's >= good enough to get you started.</em></p>
+  </footer>
+</article>
+''';

--- a/lib/src/cjk_utils.dart
+++ b/lib/src/cjk_utils.dart
@@ -8,10 +8,17 @@ final _numericOnlyPattern = RegExp(r'^\d+$');
 final _startsWithWhitespacePattern = RegExp(r'^\s');
 final _startsWithArrowPattern = RegExp(r'^[-=]');
 
+const _maxAngleBracketCacheSize = 16;
 final _angleBracketPatternCache = <String, RegExp>{};
 
 RegExp _getAngleBracketPattern(String key, RegExp Function() builder) {
-  return _angleBracketPatternCache.putIfAbsent(key, builder);
+  final cached = _angleBracketPatternCache[key];
+  if (cached != null) return cached;
+  final pattern = builder();
+  if (_angleBracketPatternCache.length < _maxAngleBracketCacheSize) {
+    _angleBracketPatternCache[key] = pattern;
+  }
+  return pattern;
 }
 
 /// Returns `true` if [codeUnit] falls within a CJK character range.

--- a/lib/src/cjk_utils.dart
+++ b/lib/src/cjk_utils.dart
@@ -2,6 +2,18 @@
 /// and typography transformations.
 library cjk_utils;
 
+final _cjkEllipsisPattern = RegExp('。{3,}');
+final _singleAngleBracketPattern = RegExp(r'<([^<>\/!?][^<>]*?)>');
+final _numericOnlyPattern = RegExp(r'^\d+$');
+final _startsWithWhitespacePattern = RegExp(r'^\s');
+final _startsWithArrowPattern = RegExp(r'^[-=]');
+
+final _angleBracketPatternCache = <String, RegExp>{};
+
+RegExp _getAngleBracketPattern(String key, RegExp Function() builder) {
+  return _angleBracketPatternCache.putIfAbsent(key, builder);
+}
+
 /// Returns `true` if [codeUnit] falls within a CJK character range.
 ///
 /// Covers:
@@ -47,7 +59,7 @@ bool isCjkPunctuation(int codeUnit) {
 /// - The standard `...` → `…` conversion is handled by the base transformer.
 String normalizeCjkEllipsis(String input) {
   // Replace three or more consecutive ideographic full stops (。) with ellipsis
-  return input.replaceAll(RegExp('。{3,}'), '…');
+  return input.replaceAll(_cjkEllipsisPattern, '…');
 }
 
 /// Converts double and single angle brackets to CJK quotation marks.
@@ -90,8 +102,11 @@ String convertCjkAngleBrackets(String input,
     // Group 2: The marker (\uE001)
     // Group 3: Content (no leading/trailing whitespace)
     // Followed by >>
-    final pattern = RegExp(
-      '(${RegExp.escape(markerEscape)}*)(${RegExp.escape(doubleAngleMarker)})([^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0](?:[^<>]*[^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0])?)>>',
+    final pattern = _getAngleBracketPattern(
+      'escape:$markerEscape:marker:$doubleAngleMarker',
+      () => RegExp(
+        '(${RegExp.escape(markerEscape)}*)(${RegExp.escape(doubleAngleMarker)})([^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0](?:[^<>]*[^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0])?)>>',
+      ),
     );
 
     String output = input.replaceAllMapped(pattern, (match) {
@@ -118,8 +133,11 @@ String convertCjkAngleBrackets(String input,
   } else {
     // Simple case: no escape handling needed (or standard <<)
     // Content must not start or end with whitespace
-    final doublePattern = RegExp(
-      '${RegExp.escape(doubleAngleMarker)}([^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0](?:[^<>]*[^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0])?)>>',
+    final doublePattern = _getAngleBracketPattern(
+      'simple:$doubleAngleMarker',
+      () => RegExp(
+        '${RegExp.escape(doubleAngleMarker)}([^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0](?:[^<>]*[^<>\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0])?)>>',
+      ),
     );
 
     String output = input.replaceAllMapped(doublePattern, (match) {
@@ -133,7 +151,7 @@ String convertCjkAngleBrackets(String input,
 
 String _convertSingleAngleBrackets(String input) {
   return input.replaceAllMapped(
-    RegExp(r'<([^<>\/!?][^<>]*?)>'),
+    _singleAngleBracketPattern,
     (match) {
       final content = match[1]!;
 
@@ -155,17 +173,17 @@ String _convertSingleAngleBrackets(String input) {
 
 bool _shouldSkipAngleBracket(String content) {
   // Skip if content is purely numeric (e.g. <10>, <3>)
-  if (RegExp(r'^\d+$').hasMatch(content)) {
+  if (_numericOnlyPattern.hasMatch(content)) {
     return true;
   }
 
   // Skip if content starts with whitespace (broken HTML tags like < div>)
-  if (RegExp(r'^\s').hasMatch(content)) {
+  if (_startsWithWhitespacePattern.hasMatch(content)) {
     return true;
   }
 
   // Skip arrow patterns: <->, <-, <=
-  if (RegExp(r'^[-=]').hasMatch(content)) {
+  if (_startsWithArrowPattern.hasMatch(content)) {
     return true;
   }
 

--- a/lib/src/smartypants_base.dart
+++ b/lib/src/smartypants_base.dart
@@ -73,6 +73,9 @@ class SmartyPantsConfig {
 /// (`<script>`, `<style>`, `<pre>`, `<code>`, `<kbd>`, `<math>`,
 /// `<textarea>`) are preserved and never transformed.
 class SmartyPants {
+  static final _quotePattern = RegExp(r'"([^"]+)"');
+  static final _whitespacePattern = RegExp(r'\s+');
+
   /// Transforms [input] into typographically correct text.
   ///
   /// Applies the following transformations to plain text content:
@@ -228,7 +231,7 @@ class SmartyPants {
 
     // Replace straight quotes with smart quotes
     output = output.replaceAllMapped(
-      RegExp(r'"([^"]+)"'),
+      _quotePattern,
       (match) => '\u201C${match[1]}\u201D',
     );
 
@@ -242,7 +245,7 @@ class SmartyPants {
     output = output.replaceAll("'", '\u2019');
 
     // Replace multiple spaces with a single space
-    output = output.replaceAll(RegExp(r'\s+'), ' ');
+    output = output.replaceAll(_whitespacePattern, ' ');
 
     // Replace ellipsis
     output = output.replaceAll('...', '\u2026');

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -1,9 +1,22 @@
-enum TokenType { text, html }
+/// The type of a [Token]: either raw text or an HTML tag/element.
+enum TokenType {
+  /// Plain text content that is not part of an HTML tag.
+  text,
 
+  /// An HTML tag, comment, or special element (e.g. `<b>`, `<!-- ... -->`).
+  html,
+}
+
+/// A single unit produced by [tokenize], representing either a span of plain
+/// text or an HTML tag/element.
 class Token {
+  /// The kind of content this token holds.
   final TokenType type;
+
+  /// The raw string content of this token.
   final String content;
 
+  /// Creates a token with the given [type] and [content].
   Token(this.type, this.content);
 
   @override
@@ -21,6 +34,13 @@ class Token {
   int get hashCode => type.hashCode ^ content.hashCode;
 }
 
+/// Splits [input] into a list of [Token]s, alternating between plain-text
+/// spans and HTML tags/elements.
+///
+/// Special tags (`<script>`, `<style>`, `<pre>`, `<code>`, `<kbd>`,
+/// `<math>`, `<textarea>`) and their inner content are returned as a single
+/// [TokenType.html] token so that SmartyPants transformations are not applied
+/// inside them.
 List<Token> tokenize(String input) {
   final tokens = <Token>[];
   final scanner = _Scanner(input);

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -81,7 +81,7 @@ class _Scanner {
 
     // Check strict start of tag name
     // Must start with letter, !, or ? (for comments/doctype)
-    if (isDone || !(peek().contains(RegExp(r'[a-zA-Z!?]')))) {
+    if (isDone || !_isTagStartChar(_input.codeUnitAt(_index))) {
       _index = start;
       return null;
     }
@@ -89,7 +89,7 @@ class _Scanner {
     // Scan tag name
     final nameStart = _index;
     while (!isDone &&
-        (peek().contains(RegExp(r'[a-zA-Z0-9!?]')) ||
+        (_isTagNameChar(_input.codeUnitAt(_index)) ||
             peek() == ':' ||
             peek() == '_' ||
             peek() == '-')) {
@@ -183,6 +183,17 @@ class _Scanner {
   void advance() {
     _index++;
   }
+
+  static bool _isTagStartChar(int c) =>
+      (c >= 0x41 && c <= 0x5A) || // A-Z
+      (c >= 0x61 && c <= 0x7A) || // a-z
+      c == 0x21 || c == 0x3F; // ! ?
+
+  static bool _isTagNameChar(int c) =>
+      (c >= 0x41 && c <= 0x5A) || // A-Z
+      (c >= 0x61 && c <= 0x7A) || // a-z
+      (c >= 0x30 && c <= 0x39) || // 0-9
+      c == 0x21 || c == 0x3F; // ! ?
 
   bool _isSpecialTag(String tagName) {
     const specialTags = {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -187,13 +187,15 @@ class _Scanner {
   static bool _isTagStartChar(int c) =>
       (c >= 0x41 && c <= 0x5A) || // A-Z
       (c >= 0x61 && c <= 0x7A) || // a-z
-      c == 0x21 || c == 0x3F; // ! ?
+      c == 0x21 ||
+      c == 0x3F; // ! ?
 
   static bool _isTagNameChar(int c) =>
       (c >= 0x41 && c <= 0x5A) || // A-Z
       (c >= 0x61 && c <= 0x7A) || // a-z
       (c >= 0x30 && c <= 0x39) || // 0-9
-      c == 0x21 || c == 0x3F; // ! ?
+      c == 0x21 ||
+      c == 0x3F; // ! ?
 
   bool _isSpecialTag(String tagName) {
     const specialTags = {


### PR DESCRIPTION
## Summary

Replace inline `RegExp` construction with pre-compiled constants across `smartypants_base.dart`, `cjk_utils.dart`, and `tokenizer.dart`, and replace character-class regex checks in the tokenizer's scan loop with direct integer comparisons. Add a `benchmark/` script to establish a performance baseline.

## Background / Motivation

All `RegExp` instances were created inline at call sites, meaning they were recompiled on every `formatText()` invocation. For applications that call `formatText()` at high frequency (e.g., a `TextInputFormatter` processing keystrokes), this introduces unnecessary object allocation per call.

The `_Scanner` class in `tokenizer.dart` additionally used `RegExp` for simple character-class checks inside a per-character loop — a particularly wasteful pattern since these can be replaced with direct integer comparisons at zero allocation cost.

This change also adds a benchmark script so that future performance work has a measured baseline to compare against.

## Related Issues

- Closes #23

## Changes

- **`lib/src/smartypants_base.dart`** — extract `RegExp(r'"([^"]+)"')` and `RegExp(r'\s+')` to `static final` class-level constants
- **`lib/src/cjk_utils.dart`** — extract five fixed patterns to top-level `final` constants; add a `Map<String, RegExp>` cache for the two parameterized patterns in `convertCjkAngleBrackets()`
- **`lib/src/tokenizer.dart`** — replace `peek().contains(RegExp(...))` calls in the tag-scan loop with `static` helper methods (`_isTagStartChar`, `_isTagNameChar`) using `codeUnitAt()` integer comparisons
- **`benchmark/smartypants_benchmark.dart`** *(new)* — four benchmark scenarios (small, large, CJK-heavy, HTML-heavy) using `Stopwatch`, runnable via `dart run benchmark/smartypants_benchmark.dart`

## Test Plan

- Commands run:
    - `dart test` — all 85 tests pass
    - `cd example && flutter test`
    - `dart run benchmark/smartypants_benchmark.dart`
- Notes:
    - Benchmark results before and after (1,000 iterations each, same machine):

      | Scenario | Before | After | Δ |
      |---|---|---|---|
      | Small input (95 chars) | 31.1 µs/call | 29.1 µs/call | -6.4% |
      | Large input (7,235 chars) | 782.7 µs/call | 771.4 µs/call | -1.4% |
      | CJK-heavy (1,283 chars) | 544.4 µs/call | 547.6 µs/call | ≈0% (noise) |
      | HTML-heavy (3,695 chars) | 431.9 µs/call | 375.5 µs/call | **-13.1%** |

    - The HTML-heavy improvement is driven by the tokenizer loop optimization: replacing `RegExp` object allocation on every character with `codeUnitAt()` integer comparisons eliminates repeated allocation inside the scan hot path. The effect scales with tag density rather than raw input length.
    - CJK results are within measurement noise — the bottleneck there is pattern-matching computation, which pre-compilation does not reduce.

## Documentation (If Needed)

- None required. `benchmark/` is a developer-only script; no public API was changed.

## Breaking Change (If Any)

- None. All changes are internal implementation details with identical observable behavior.
