### PR TITLE
feat: add granular transformation options to SmartyPantsConfig

### DIFF
--- a/example/lib/example_card.dart
+++ b/example/lib/example_card.dart
@@ -21,7 +21,8 @@ class ExampleCard extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final effectiveConfig = item.config ?? config;
-    final formatted = SmartyPants.formatText(item.input, config: effectiveConfig);
+    final formatted =
+        SmartyPants.formatText(item.input, config: effectiveConfig);
 
     return Card(
       elevation: 0,

--- a/example/lib/example_card.dart
+++ b/example/lib/example_card.dart
@@ -20,7 +20,8 @@ class ExampleCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final formatted = SmartyPants.formatText(item.input, config: config);
+    final effectiveConfig = item.config ?? config;
+    final formatted = SmartyPants.formatText(item.input, config: effectiveConfig);
 
     return Card(
       elevation: 0,

--- a/example/lib/example_data.dart
+++ b/example/lib/example_data.dart
@@ -7,10 +7,12 @@ import 'package:smartypants/smartypants.dart';
 class ExampleItem {
   final String description;
   final String input;
+  final SmartyPantsConfig? config;
 
   const ExampleItem({
     required this.description,
     required this.input,
+    this.config,
   });
 }
 
@@ -153,6 +155,48 @@ const List<ExampleCategory> exampleCategories = [
         description: 'Mixed HTML & text',
         input:
             '<h1>"Title"</h1>\n<p>"Item 1" -- Description</p>\n<p>"Item 2" --- Description</p>',
+      ),
+    ],
+  ),
+  ExampleCategory(
+    name: 'Granular Config',
+    icon: '⚙',
+    summary: 'Per-transformation control with SmartyPantsConfig',
+    items: [
+      ExampleItem(
+        description: 'Quotes only (dashes disabled)',
+        input: '"Hello" -- World',
+        config: SmartyPantsConfig(dashes: false),
+      ),
+      ExampleItem(
+        description: 'Dashes only (quotes disabled)',
+        input: '"Hello" -- World',
+        config: SmartyPantsConfig(quotes: false),
+      ),
+      ExampleItem(
+        description: 'No whitespace normalization',
+        input: 'Hello   World...',
+        config: SmartyPantsConfig(whitespaceNormalization: false),
+      ),
+      ExampleItem(
+        description: 'Arrows disabled',
+        input: 'Step 1 -> Step 2 => Done',
+        config: SmartyPantsConfig(arrows: false),
+      ),
+      ExampleItem(
+        description: 'Math symbols disabled',
+        input: 'x >= 10 and y != 0',
+        config: SmartyPantsConfig(mathSymbols: false),
+      ),
+      ExampleItem(
+        description: 'CJK ellipsis disabled (ASCII ellipsis still works)',
+        input: 'Hello... 기다려주세요。。。',
+        config: SmartyPantsConfig(cjkEllipsisNormalization: false),
+      ),
+      ExampleItem(
+        description: 'CJK angle brackets disabled',
+        input: '책<<제목>>을 읽었다',
+        config: SmartyPantsConfig(cjkAngleBrackets: false),
       ),
     ],
   ),

--- a/example/lib/examples_tab.dart
+++ b/example/lib/examples_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:smartypants/smartypants.dart';
 
 import 'example_card.dart';
 import 'example_data.dart';
@@ -6,7 +7,7 @@ import 'example_data.dart';
 /// A tab that displays preset transformation examples grouped by category.
 class ExamplesTab extends StatelessWidget {
   /// Called when the user taps "Try it" on an example card.
-  final ValueChanged<String>? onTryExample;
+  final void Function(String, SmartyPantsConfig?)? onTryExample;
 
   const ExamplesTab({super.key, this.onTryExample});
 
@@ -35,7 +36,7 @@ class _CategorySection extends StatelessWidget {
   final ExampleCategory category;
   final ColorScheme colorScheme;
   final ThemeData theme;
-  final ValueChanged<String>? onTryExample;
+  final void Function(String, SmartyPantsConfig?)? onTryExample;
 
   const _CategorySection({
     required this.category,
@@ -99,7 +100,8 @@ class _CategorySection extends StatelessWidget {
                 item: item,
                 config: category.config,
                 onTryIt: onTryExample != null
-                    ? () => onTryExample!(item.input)
+                    ? () => onTryExample!(
+                        item.input, item.config ?? category.config)
                     : null,
               ),
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:smartypants/smartypants.dart';
 
 import 'examples_tab.dart';
 import 'playground_tab.dart';
@@ -55,13 +56,13 @@ class _HomePageState extends State<HomePage>
     super.dispose();
   }
 
-  void _onTryExample(String inputText) {
+  void _onTryExample(String inputText, SmartyPantsConfig? config) {
     // Switch to Playground tab and inject the text
     _tabController.animateTo(0);
     // Wait for animation to settle, then set text
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _playgroundKey.currentState?.setInput(inputText);
+      _playgroundKey.currentState?.setInput(inputText, config: config);
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Example loaded in Playground'),

--- a/example/lib/playground_tab.dart
+++ b/example/lib/playground_tab.dart
@@ -19,21 +19,24 @@ class PlaygroundTabState extends State<PlaygroundTab> {
   final TextEditingController _controller = TextEditingController();
   String _formattedText = '';
   bool _useFormatter = false;
+  SmartyPantsConfig? _config;
 
   @override
   void initState() {
     super.initState();
     if (widget.initialText != null && widget.initialText!.isNotEmpty) {
       _controller.text = widget.initialText!;
-      _formattedText = SmartyPants.formatText(widget.initialText!);
+      _formattedText =
+          SmartyPants.formatText(widget.initialText!, config: _config);
     }
   }
 
   /// Sets the input text programmatically (e.g. from an example card).
-  void setInput(String text) {
+  void setInput(String text, {SmartyPantsConfig? config}) {
     _controller.text = text;
     setState(() {
-      _formattedText = SmartyPants.formatText(text);
+      _config = config;
+      _formattedText = SmartyPants.formatText(text, config: _config);
     });
   }
 
@@ -42,7 +45,8 @@ class PlaygroundTabState extends State<PlaygroundTab> {
     // (like the clear button visibility) can update.
     setState(() {
       if (!_useFormatter) {
-        _formattedText = value.isEmpty ? '' : SmartyPants.formatText(value);
+        _formattedText =
+            value.isEmpty ? '' : SmartyPants.formatText(value, config: _config);
       }
     });
   }
@@ -51,6 +55,7 @@ class PlaygroundTabState extends State<PlaygroundTab> {
     _controller.clear();
     setState(() {
       _formattedText = '';
+      _config = null;
     });
   }
 
@@ -112,7 +117,8 @@ class PlaygroundTabState extends State<PlaygroundTab> {
                       if (!value) {
                         _formattedText = _controller.text.isEmpty
                             ? ''
-                            : SmartyPants.formatText(_controller.text);
+                            : SmartyPants.formatText(_controller.text,
+                                config: _config);
                       }
                     });
                   },
@@ -127,7 +133,7 @@ class PlaygroundTabState extends State<PlaygroundTab> {
             maxLines: 5,
             minLines: 3,
             inputFormatters: _useFormatter
-                ? <TextInputFormatter>[SmartypantsFormatter()]
+                ? <TextInputFormatter>[SmartypantsFormatter(config: _config)]
                 : null,
             style: theme.textTheme.bodyMedium?.copyWith(
               fontFamily: 'monospace',

--- a/test/smartypants_cjk_test.dart
+++ b/test/smartypants_cjk_test.dart
@@ -376,4 +376,101 @@ void main() {
       expect(result, equals('See 〈書籍 Book〉'));
     });
   });
+
+  group('CJK per-transformation flags', () {
+    // cjkEllipsisNormalization
+
+    test('cjkEllipsisNormalization=false preserves ideographic full stops', () {
+      const config = SmartyPantsConfig(cjkEllipsisNormalization: false);
+      expect(
+        SmartyPants.formatText('기다려주세요。。。', config: config),
+        '기다려주세요。。。',
+      );
+    });
+
+    test('cjkEllipsisNormalization=false does not affect ASCII ellipsis', () {
+      const config = SmartyPantsConfig(cjkEllipsisNormalization: false);
+      expect(
+        SmartyPants.formatText('Hello...', config: config),
+        'Hello\u2026',
+      );
+    });
+
+    test('cjkEllipsisNormalization=false does not affect angle brackets', () {
+      const config = SmartyPantsConfig(cjkEllipsisNormalization: false);
+      expect(
+        SmartyPants.formatText('책<<제목>>', config: config),
+        '책《제목》',
+      );
+    });
+
+    // cjkAngleBrackets
+
+    test('cjkAngleBrackets=false preserves double angle brackets', () {
+      const config = SmartyPantsConfig(cjkAngleBrackets: false);
+      expect(
+        SmartyPants.formatText('책<<제목>>', config: config),
+        '책<<제목>>',
+      );
+    });
+
+    test('cjkAngleBrackets=false preserves single CJK angle brackets', () {
+      const config = SmartyPantsConfig(cjkAngleBrackets: false);
+      expect(
+        SmartyPants.formatText('한국어<작품>텍스트', config: config),
+        '한국어<작품>텍스트',
+      );
+    });
+
+    test('cjkAngleBrackets=false does not affect CJK ellipsis', () {
+      const config = SmartyPantsConfig(cjkAngleBrackets: false);
+      expect(
+        SmartyPants.formatText('기다려주세요。。。', config: config),
+        '기다려주세요\u2026',
+      );
+    });
+
+    // combinations
+
+    test('both CJK flags false disables both CJK transforms', () {
+      const config = SmartyPantsConfig(
+        cjkEllipsisNormalization: false,
+        cjkAngleBrackets: false,
+      );
+      expect(
+        SmartyPants.formatText('책<<제목>> 기다려주세요。。。', config: config),
+        '책<<제목>> 기다려주세요。。。',
+      );
+    });
+
+    test('ellipsis=false and cjkEllipsisNormalization=false preserves all ellipsis forms', () {
+      const config = SmartyPantsConfig(
+        ellipsis: false,
+        cjkEllipsisNormalization: false,
+      );
+      expect(
+        SmartyPants.formatText('Hello... 기다려주세요。。。', config: config),
+        'Hello... 기다려주세요。。。',
+      );
+    });
+
+    test('smart=false overrides CJK flags', () {
+      const config = SmartyPantsConfig(
+        smart: false,
+        cjkEllipsisNormalization: true,
+        cjkAngleBrackets: true,
+      );
+      expect(
+        SmartyPants.formatText('기다려주세요。。。', config: config),
+        '기다려주세요。。。',
+      );
+    });
+
+    test('default config still applies both CJK transforms (regression)', () {
+      expect(
+        SmartyPants.formatText('책<<제목>> 기다려주세요。。。'),
+        '책《제목》 기다려주세요\u2026',
+      );
+    });
+  });
 }

--- a/test/smartypants_cjk_test.dart
+++ b/test/smartypants_cjk_test.dart
@@ -443,7 +443,9 @@ void main() {
       );
     });
 
-    test('ellipsis=false and cjkEllipsisNormalization=false preserves all ellipsis forms', () {
+    test(
+        'ellipsis=false and cjkEllipsisNormalization=false preserves all ellipsis forms',
+        () {
       const config = SmartyPantsConfig(
         ellipsis: false,
         cjkEllipsisNormalization: false,

--- a/test/smartypants_test.dart
+++ b/test/smartypants_test.dart
@@ -51,4 +51,233 @@ void main() {
       expect(SmartyPants.formatText(input), expected);
     });
   });
+
+  group('SmartyPantsConfig per-transformation flags', () {
+    // quotes
+
+    test('quotes=false disables double quote transformation', () {
+      const config = SmartyPantsConfig(quotes: false);
+      expect(
+        SmartyPants.formatText('"Hello, World!"', config: config),
+        '"Hello, World!"',
+      );
+    });
+
+    test('quotes=false disables apostrophe transformation', () {
+      const config = SmartyPantsConfig(quotes: false);
+      expect(
+        SmartyPants.formatText("It's a test.", config: config),
+        "It's a test.",
+      );
+    });
+
+    test('quotes=false does not affect dashes', () {
+      const config = SmartyPantsConfig(quotes: false);
+      expect(SmartyPants.formatText('A--B', config: config), 'A\u2013B');
+    });
+
+    // dashes
+
+    test('dashes=false disables en dash transformation', () {
+      const config = SmartyPantsConfig(dashes: false);
+      expect(SmartyPants.formatText('A--B', config: config), 'A--B');
+    });
+
+    test('dashes=false disables em dash transformation', () {
+      const config = SmartyPantsConfig(dashes: false);
+      expect(SmartyPants.formatText('A---B', config: config), 'A---B');
+    });
+
+    test('dashes=false does not affect quotes', () {
+      const config = SmartyPantsConfig(dashes: false);
+      expect(
+        SmartyPants.formatText('"Hello"', config: config),
+        '\u201CHello\u201D',
+      );
+    });
+
+    // ellipsis
+
+    test('ellipsis=false disables ASCII ellipsis transformation', () {
+      const config = SmartyPantsConfig(ellipsis: false);
+      expect(SmartyPants.formatText('Hello...', config: config), 'Hello...');
+    });
+
+    test('ellipsis=false does not affect dashes', () {
+      const config = SmartyPantsConfig(ellipsis: false);
+      expect(SmartyPants.formatText('A--B', config: config), 'A\u2013B');
+    });
+
+    // mathSymbols
+
+    test('mathSymbols=false disables >= transformation', () {
+      const config = SmartyPantsConfig(mathSymbols: false);
+      expect(SmartyPants.formatText('x >= 10', config: config), 'x >= 10');
+    });
+
+    test('mathSymbols=false disables <= transformation', () {
+      const config = SmartyPantsConfig(mathSymbols: false);
+      expect(SmartyPants.formatText('y <= 20', config: config), 'y <= 20');
+    });
+
+    test('mathSymbols=false disables != transformation', () {
+      const config = SmartyPantsConfig(mathSymbols: false);
+      expect(SmartyPants.formatText('a != b', config: config), 'a != b');
+    });
+
+    test('mathSymbols=false does not affect arrows', () {
+      const config = SmartyPantsConfig(mathSymbols: false);
+      expect(
+        SmartyPants.formatText('A -> B', config: config),
+        'A \u2192 B',
+      );
+    });
+
+    // arrows
+
+    test('arrows=false disables right arrow transformation', () {
+      const config = SmartyPantsConfig(arrows: false);
+      expect(SmartyPants.formatText('A -> B', config: config), 'A -> B');
+    });
+
+    test('arrows=false disables left arrow transformation', () {
+      const config = SmartyPantsConfig(arrows: false);
+      expect(SmartyPants.formatText('B <- A', config: config), 'B <- A');
+    });
+
+    test('arrows=false disables bidirectional arrow transformation', () {
+      const config = SmartyPantsConfig(arrows: false);
+      expect(SmartyPants.formatText('A <-> B', config: config), 'A <-> B');
+    });
+
+    test('arrows=false disables fat arrow transformation', () {
+      const config = SmartyPantsConfig(arrows: false);
+      expect(
+        SmartyPants.formatText('cond => result', config: config),
+        'cond => result',
+      );
+    });
+
+    test('arrows=false does not affect mathSymbols', () {
+      const config = SmartyPantsConfig(arrows: false);
+      expect(SmartyPants.formatText('x >= 10', config: config), 'x \u2265 10');
+    });
+
+    // whitespaceNormalization
+
+    test('whitespaceNormalization=false preserves multiple spaces', () {
+      const config = SmartyPantsConfig(whitespaceNormalization: false);
+      expect(
+        SmartyPants.formatText('Hello   World', config: config),
+        'Hello   World',
+      );
+    });
+
+    test('whitespaceNormalization=false does not affect quotes', () {
+      const config = SmartyPantsConfig(whitespaceNormalization: false);
+      expect(
+        SmartyPants.formatText('"Hello"', config: config),
+        '\u201CHello\u201D',
+      );
+    });
+
+    // combinations
+
+    test('quotes and dashes can be independently disabled', () {
+      const config = SmartyPantsConfig(quotes: false, dashes: false);
+      expect(
+        SmartyPants.formatText('"Hello" -- World...', config: config),
+        '"Hello" -- World\u2026',
+      );
+    });
+
+    test('all flags false except ellipsis', () {
+      const config = SmartyPantsConfig(
+        quotes: false,
+        dashes: false,
+        mathSymbols: false,
+        arrows: false,
+        whitespaceNormalization: false,
+        cjkEllipsisNormalization: false,
+        cjkAngleBrackets: false,
+      );
+      expect(
+        SmartyPants.formatText('"Hello"  -- World... -> end', config: config),
+        '"Hello"  -- World\u2026 -> end',
+      );
+    });
+
+    test('smart=false overrides all individual flags', () {
+      const config = SmartyPantsConfig(
+        smart: false,
+        quotes: true,
+        dashes: true,
+        ellipsis: true,
+        mathSymbols: true,
+        arrows: true,
+      );
+      expect(
+        SmartyPants.formatText('"Hello" -- World...', config: config),
+        '"Hello" -- World...',
+      );
+    });
+
+    // copyWith
+
+    test('copyWith preserves unchanged fields', () {
+      const original = SmartyPantsConfig(
+        locale: SmartyPantsLocale.ko,
+        dashes: false,
+      );
+      final copy = original.copyWith(ellipsis: false);
+      expect(copy.locale, SmartyPantsLocale.ko);
+      expect(copy.dashes, false);
+      expect(copy.ellipsis, false);
+      expect(copy.quotes, true);
+    });
+
+    test('copyWith can re-enable a disabled flag', () {
+      const original = SmartyPantsConfig(dashes: false);
+      final copy = original.copyWith(dashes: true);
+      expect(copy.dashes, true);
+      expect(
+        SmartyPants.formatText('A--B', config: copy),
+        'A\u2013B',
+      );
+    });
+  });
+
+  group('SmartyPantsConfig default backward compatibility', () {
+    test('default config produces same output as explicit all-true config', () {
+      const inputs = [
+        '"Hello, World!"',
+        "It's a test.",
+        'A--B',
+        'A---B',
+        'Hello...',
+        'x >= 10',
+        'A -> B',
+        'This  is  spaced',
+      ];
+      final defaultConfig = const SmartyPantsConfig();
+      const allTrueConfig = SmartyPantsConfig(
+        smart: true,
+        quotes: true,
+        dashes: true,
+        ellipsis: true,
+        mathSymbols: true,
+        arrows: true,
+        whitespaceNormalization: true,
+        cjkEllipsisNormalization: true,
+        cjkAngleBrackets: true,
+      );
+      for (final input in inputs) {
+        expect(
+          SmartyPants.formatText(input, config: defaultConfig),
+          SmartyPants.formatText(input, config: allTrueConfig),
+          reason: 'Input "$input" differs between default and all-true config',
+        );
+      }
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Add per-transformation boolean flags to `SmartyPantsConfig`, allowing users to selectively enable or disable individual typographic transformations instead of relying solely on the all-or-nothing `smart` toggle. Also adds a `copyWith` method for idiomatic Dart config mutation.

## Background / Motivation

`SmartyPantsConfig` previously offered only a single `smart: true/false` toggle. Users who wanted smart quotes but not arrow replacements, or CJK ellipsis normalization but not angle bracket conversion, had no way to achieve this without post-processing workarounds. This change brings fine-grained control over every transformation category while preserving full backward compatibility.

## Related Issues

- Closes #20

## Changes

- **`SmartyPantsConfig`** — added 8 new boolean flags (all default `true`):
  - `quotes` — controls `"text"` → `"text"` and `'` → `'`
  - `dashes` — controls `--` → `–` and `---` → `—`
  - `ellipsis` — controls `...` → `…`
  - `mathSymbols` — controls `>=` → `≥`, `<=` → `≤`, `!=` → `≠`
  - `arrows` — controls `->` → `→`, `<-` → `←`, `<->` → `↔`, `=>` → `⇒`
  - `whitespaceNormalization` — controls collapsing of multiple spaces
  - `cjkEllipsisNormalization` — controls `。。。` → `…`
  - `cjkAngleBrackets` — controls `<<>>` → `《》` and `<CJK>` → `〈〉`
- **`SmartyPantsConfig.copyWith`** — new method for creating modified copies (consistent with Flutter conventions)
- **`_applyTransformations`** — refactored to accept `SmartyPantsConfig` instead of `SmartyPantsLocale`; each transformation block is now gated by its corresponding flag
- **`ExampleItem`** — added optional `config` field to support item-level config in the example app
- **`ExampleCard`** — item-level config takes precedence over category-level config
- **Example app** — added "Granular Config" category (7 examples demonstrating per-flag control)

## Test Plan

- Commands run:
  - `dart test` — all **120 tests** passed (57 pre-existing + 63 new)
- New test groups added:
  - `SmartyPantsConfig per-transformation flags` — verifies each flag disables only its own transformation and does not affect others; tests combinations and `smart=false` override
  - `SmartyPantsConfig default backward compatibility` — verifies default config produces identical output to an explicit all-`true` config
  - `CJK per-transformation flags` — verifies `cjkEllipsisNormalization` and `cjkAngleBrackets` flags in isolation and combination; regression test for default behavior

## Documentation (If Needed)

- All new fields on `SmartyPantsConfig` include Dartdoc comments with transformation examples and Unicode code points
- `SmartyPantsConfig` class-level doc updated with new usage examples for per-transformation configuration

## Breaking Change (If Any)

- Migration notes:
  - No breaking changes. All new flags default to `true`, preserving existing behavior. Existing code using `SmartyPantsConfig()` or `SmartyPantsConfig(smart: false)` continues to work without modification.
