### PR TITLE
feat: protect Markdown code regions from typographic transformations

### DIFF
--- a/benchmark/smartypants_benchmark.dart
+++ b/benchmark/smartypants_benchmark.dart
@@ -12,6 +12,11 @@ void main() {
   runBenchmark('HTML-heavy', _htmlInput, iterations: 1000);
   runBenchmark('Markdown-light', _markdownLightInput, iterations: 1000);
   runBenchmark('Markdown-heavy', _markdownHeavyInput, iterations: 1000);
+  runBenchmark(
+    'Adversarial unmatched backticks (O(n) check)',
+    _adversarialUnmatchedBackticks,
+    iterations: 100,
+  );
 }
 
 void runBenchmark(
@@ -43,6 +48,14 @@ void runBenchmark(
 // ---------------------------------------------------------------------------
 // Benchmark inputs
 // ---------------------------------------------------------------------------
+
+/// 500 unmatched backtick runs of varying lengths separated by prose.
+/// Without the _noCloserPastEnd short-circuit this would be O(n²); with it,
+/// each distinct count is scanned at most once → O(n).
+final _adversarialUnmatchedBackticks = List.generate(
+  500,
+  (i) => '${'`' * (i % 5 + 1)} a->b',
+).join(' ');
 
 const _smallInput = 'She said "Hello, world!" -- it\'s a great day... '
     'and the result is >= 10 or <= 5, so -> proceed!';

--- a/example/lib/example_data.dart
+++ b/example/lib/example_data.dart
@@ -224,4 +224,39 @@ const List<ExampleCategory> exampleCategories = [
       ),
     ],
   ),
+  ExampleCategory(
+    name: 'Markdown Support',
+    icon: '`',
+    summary: 'Code spans and fenced blocks are preserved during transformation',
+    items: [
+      ExampleItem(
+        description: 'Inline code (single backtick)',
+        input: 'Use `a->b` to indicate direction.',
+      ),
+      ExampleItem(
+        description: 'Inline code (double backtick)',
+        input: 'Check ``x != y`` for inequality.',
+      ),
+      ExampleItem(
+        description: 'Inline code with backtick inside',
+        input: 'Try `` ` `` as a literal backtick.',
+      ),
+      ExampleItem(
+        description: 'Fenced code block (backticks)',
+        input: '```\nx != y\na->b\n```',
+      ),
+      ExampleItem(
+        description: 'Fenced code block (tildes)',
+        input: '~~~\nx != y\na->b\n~~~',
+      ),
+      ExampleItem(
+        description: 'Mixed prose and code',
+        input: '"Smart quotes" outside, `a->b` inside.',
+      ),
+      ExampleItem(
+        description: 'Multiple inline spans',
+        input: 'Use `->` for arrow and `--` for dash.',
+      ),
+    ],
+  ),
 ];

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -195,6 +195,42 @@ void main() {
     );
   });
 
+  test('exampleCategories includes Markdown Support with examples', () {
+    final markdownCategory = exampleCategories.firstWhere(
+      (c) => c.name == 'Markdown Support',
+    );
+    expect(markdownCategory.items, isNotEmpty);
+    expect(
+      markdownCategory.items.any((item) => item.input.contains('`')),
+      isTrue,
+      reason: 'Markdown category should include an inline code example',
+    );
+  });
+
+  testWidgets('Playground preserves inline code from transformation',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    final textField = find.byType(TextField);
+    await tester.enterText(textField, '`a->b`');
+    await tester.pump();
+
+    // Arrow inside backtick span must NOT be transformed to →
+    expect(find.text('`a\u2192b`'), findsNothing);
+  });
+
+  testWidgets('Playground transforms prose but preserves inline code',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    final textField = find.byType(TextField);
+    await tester.enterText(textField, '"text" `a->b`');
+    await tester.pump();
+
+    // Smart quotes applied to prose; arrow inside backtick span unchanged
+    expect(find.text('\u201ctext\u201d `a->b`'), findsWidgets);
+  });
+
   testWidgets('Live Format mode transforms CJK text as user types',
       (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());

--- a/lib/src/smartypants_base.dart
+++ b/lib/src/smartypants_base.dart
@@ -256,7 +256,7 @@ class SmartyPants {
     const escapeChar = '\uE000';
 
     for (final token in tokens) {
-      if (token.type == TokenType.html) {
+      if (token.type == TokenType.html || token.type == TokenType.markdown) {
         htmlPlaceholders.add(token.content);
         buffer.write(placeholderChar);
       } else {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -1,10 +1,15 @@
-/// The type of a [Token]: either raw text or an HTML tag/element.
+/// The type of a [Token]: either raw text, an HTML tag/element, or a Markdown
+/// code region.
 enum TokenType {
   /// Plain text content that is not part of an HTML tag.
   text,
 
   /// An HTML tag, comment, or special element (e.g. `<b>`, `<!-- ... -->`).
   html,
+
+  /// A Markdown inline code span (e.g. `` `code` ``, ` ``code`` `) or fenced
+  /// code block (e.g. ` ``` `, `~~~`). Content inside is never transformed.
+  markdown,
 }
 
 /// A single unit produced by [tokenize], representing either a span of plain
@@ -35,12 +40,16 @@ class Token {
 }
 
 /// Splits [input] into a list of [Token]s, alternating between plain-text
-/// spans and HTML tags/elements.
+/// spans, HTML tags/elements, and Markdown code regions.
 ///
-/// Special tags (`<script>`, `<style>`, `<pre>`, `<code>`, `<kbd>`,
+/// Special HTML tags (`<script>`, `<style>`, `<pre>`, `<code>`, `<kbd>`,
 /// `<math>`, `<textarea>`) and their inner content are returned as a single
 /// [TokenType.html] token so that SmartyPants transformations are not applied
 /// inside them.
+///
+/// Markdown inline code spans (`` `code` ``, ` ``code`` `) and fenced code
+/// blocks (` ``` `, `~~~`) are returned as [TokenType.markdown] tokens and are
+/// likewise excluded from transformations.
 List<Token> tokenize(String input) {
   final tokens = <Token>[];
   final scanner = _Scanner(input);
@@ -54,7 +63,9 @@ List<Token> tokenize(String input) {
   }
 
   while (!scanner.isDone) {
-    if (scanner.peek() == '<') {
+    final ch = scanner.peek();
+
+    if (ch == '<') {
       final token = scanner.scanTag();
       if (token != null) {
         flushText();
@@ -63,6 +74,19 @@ List<Token> tokenize(String input) {
       }
       // Not a tag, consume '<' as text
       textBuffer.write('<');
+      scanner.advance();
+      continue;
+    }
+
+    if (ch == '`' || ch == '~') {
+      final token = scanner.scanMarkdown();
+      if (token != null) {
+        flushText();
+        tokens.add(token);
+        continue;
+      }
+      // Not a Markdown code region, consume the character as text
+      textBuffer.write(ch);
       scanner.advance();
       continue;
     }
@@ -181,10 +205,100 @@ class _Scanner {
 
   String scanText() {
     final start = _index;
-    while (!isDone && peek() != '<') {
+    while (!isDone && peek() != '<' && peek() != '`' && peek() != '~') {
       advance();
     }
     return _input.substring(start, _index);
+  }
+
+  /// Attempts to scan a Markdown inline code span or fenced code block
+  /// starting at the current position.
+  ///
+  /// Returns a [TokenType.markdown] token on success, or `null` if the
+  /// current position does not begin a valid Markdown code region (in which
+  /// case the scanner position is restored to where it was before the call).
+  Token? scanMarkdown() {
+    final start = _index;
+    final fenceChar = peek();
+
+    if (fenceChar != '`' && fenceChar != '~') return null;
+
+    // Count consecutive opening characters
+    final openStart = _index;
+    while (!isDone && peek() == fenceChar) {
+      advance();
+    }
+    final openCount = _index - openStart;
+
+    // Tildes: fewer than 3 do not start a code region — backtrack
+    if (fenceChar == '~') {
+      if (openCount < 3) {
+        _index = start;
+        return null;
+      }
+      return _scanFencedBlock(start, fenceChar, openCount);
+    }
+
+    // Backticks: 3 or more start a fenced code block
+    if (openCount >= 3) {
+      return _scanFencedBlock(start, fenceChar, openCount);
+    }
+
+    // Backticks 1–2: inline code span
+    // Search for a closing run of exactly the same count
+    while (!isDone) {
+      if (peek() != '`') {
+        advance();
+        continue;
+      }
+      final closeStart = _index;
+      while (!isDone && peek() == '`') {
+        advance();
+      }
+      final closeCount = _index - closeStart;
+      if (closeCount == openCount) {
+        return Token(TokenType.markdown, _input.substring(start, _index));
+      }
+      // Count mismatch — keep scanning
+    }
+
+    // No closing delimiter found — backtrack and treat as plain text
+    _index = start;
+    return null;
+  }
+
+  Token _scanFencedBlock(int start, String fenceChar, int openCount) {
+    // Skip optional language identifier and the opening line's newline
+    while (!isDone && peek() != '\n') {
+      advance();
+    }
+    if (!isDone) advance(); // consume '\n'
+
+    // Search for a closing fence: a line that begins with >= openCount
+    // of the same fence character
+    while (!isDone) {
+      final lineStart = _index;
+      while (!isDone && peek() == fenceChar) {
+        advance();
+      }
+      final closeCount = _index - lineStart;
+      if (closeCount >= openCount) {
+        // Consume the rest of the closing line
+        while (!isDone && peek() != '\n') {
+          advance();
+        }
+        if (!isDone) advance(); // consume '\n'
+        return Token(TokenType.markdown, _input.substring(start, _index));
+      }
+      // Not a closing fence — advance to the end of this line
+      while (!isDone && peek() != '\n') {
+        advance();
+      }
+      if (!isDone) advance(); // consume '\n'
+    }
+
+    // Unclosed fenced block — protect everything to end of input
+    return Token(TokenType.markdown, _input.substring(start));
   }
 
   void scanQuoted(String quote) {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -85,9 +85,14 @@ List<Token> tokenize(String input) {
         tokens.add(token);
         continue;
       }
-      // Not a Markdown code region, consume the character as text
-      textBuffer.write(ch);
-      scanner.advance();
+      // scanMarkdown() backtracked — the run of fence characters does not
+      // start a valid code region.  Consume the entire run atomically so
+      // that no sub-run can be re-examined as a new opener; otherwise a
+      // later, shorter sub-run might find a spurious closing delimiter.
+      while (scanner.peek() == ch) {
+        textBuffer.write(ch);
+        scanner.advance();
+      }
       continue;
     }
 

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -86,12 +86,25 @@ List<Token> tokenize(String input) {
         continue;
       }
       // scanMarkdown() backtracked — the run of fence characters does not
-      // start a valid code region.  Consume the entire run atomically so
-      // that no sub-run can be re-examined as a new opener; otherwise a
-      // later, shorter sub-run might find a spurious closing delimiter.
-      while (scanner.peek() == ch) {
+      // start a valid code region.
+      //
+      // When the rejection was caused by the first backtick being an escaped
+      // literal (odd preceding backslashes, CommonMark §6.1), only that one
+      // backtick is consumed.  Subsequent backticks in the same run are not
+      // escaped and may open their own code span.
+      //
+      // In all other cases (no closer, tilde not at line-start, etc.) the
+      // entire run is consumed atomically so that no sub-run can be
+      // re-examined as a new opener; otherwise a later, shorter sub-run might
+      // find a spurious closing delimiter.
+      if (ch == '`' && scanner.isCurrentBacktickEscaped) {
         textBuffer.write(ch);
         scanner.advance();
+      } else {
+        while (scanner.peek() == ch) {
+          textBuffer.write(ch);
+          scanner.advance();
+        }
       }
       continue;
     }
@@ -119,6 +132,21 @@ class _Scanner {
   bool get isDone => _index >= _input.length;
 
   String peek() => isDone ? '' : _input[_index];
+
+  /// Returns true when the character at the current position is a backtick
+  /// preceded by an odd number of backslashes (CommonMark §6.1 escaped
+  /// literal).  Used by [tokenize] to decide whether to consume only the
+  /// single escaped backtick rather than the entire run.
+  bool get isCurrentBacktickEscaped {
+    if (_index >= _input.length || _input[_index] != '`') return false;
+    int count = 0;
+    int i = _index - 1;
+    while (i >= 0 && _input[i] == '\\') {
+      count++;
+      i--;
+    }
+    return count.isOdd;
+  }
 
   Token? scanTag() {
     // Save state to backtrack if not a valid tag

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -235,21 +235,23 @@ class _Scanner {
     }
     final openCount = _index - openStart;
 
-    // Tildes: fewer than 3 do not start a code region — backtrack
+    // Tildes: fewer than 3, or not at a line-start, do not start a fenced
+    // block — backtrack so the tilde run is emitted as plain text.
     if (fenceChar == '~') {
-      if (openCount < 3) {
+      if (openCount < 3 || !_isAtLineStart(start)) {
         _index = start;
         return null;
       }
       return _scanFencedBlock(start, fenceChar, openCount);
     }
 
-    // Backticks: 3 or more start a fenced code block
-    if (openCount >= 3) {
+    // Backticks: 3 or more at a line-start position → fenced code block.
+    // Mid-line runs of 3+ backticks fall through to inline-span scanning.
+    if (openCount >= 3 && _isAtLineStart(start)) {
       return _scanFencedBlock(start, fenceChar, openCount);
     }
 
-    // Backticks 1–2: inline code span
+    // Backticks 1–2 (or 3+ mid-line): inline code span
     // Search for a closing run of exactly the same count
     while (!isDone) {
       if (peek() != '`') {
@@ -350,6 +352,21 @@ class _Scanner {
       (c >= 0x30 && c <= 0x39) || // 0-9
       c == 0x21 ||
       c == 0x3F; // ! ?
+
+  /// Returns true if [pos] is a valid fenced-block opener position:
+  /// either the very start of [_input], or preceded only by up to 3 space
+  /// characters since the last newline (CommonMark §4.4–4.5).
+  bool _isAtLineStart(int pos) {
+    if (pos == 0) return true;
+    int i = pos - 1;
+    int spaces = 0;
+    while (i >= 0 && _input[i] == ' ') {
+      spaces++;
+      i--;
+    }
+    if (spaces > 3) return false;
+    return i < 0 || _input[i] == '\n';
+  }
 
   bool _isSpecialTag(String tagName) {
     const specialTags = {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -108,6 +108,12 @@ class _Scanner {
   final String _input;
   int _index = 0;
 
+  /// Backtick counts for which a left-to-right scan has already reached EOF
+  /// without finding a matching closer.  Once a count N is exhausted, no run
+  /// of N backticks exists anywhere after the current scanner position, so
+  /// future inline-span openers of the same count can be rejected in O(1).
+  final Set<int> _noCloserPastEnd = {};
+
   _Scanner(this._input);
 
   bool get isDone => _index >= _input.length;
@@ -273,7 +279,17 @@ class _Scanner {
     }
 
     // Backticks 1–2 (or 3+ mid-line): inline code span
-    // Search for a closing run of exactly the same count
+    // Search for a closing run of exactly the same count.
+    //
+    // Short-circuit: if a previous scan already reached EOF without finding a
+    // closer of this count, no such run exists anywhere after this point
+    // either (we scan left-to-right).  Reject in O(1) to keep overall
+    // tokenization O(n) even for inputs with many unmatched backtick runs.
+    if (_noCloserPastEnd.contains(openCount)) {
+      _index = start;
+      return null;
+    }
+
     while (!isDone) {
       if (peek() != '`') {
         advance();
@@ -290,7 +306,8 @@ class _Scanner {
       // Count mismatch — keep scanning
     }
 
-    // No closing delimiter found — backtrack and treat as plain text
+    // No closing delimiter found — record count as exhausted, then backtrack.
+    _noCloserPastEnd.add(openCount);
     _index = start;
     return null;
   }

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -228,6 +228,21 @@ class _Scanner {
 
     if (fenceChar != '`' && fenceChar != '~') return null;
 
+    // P2: A backtick run preceded by an odd number of backslashes begins with
+    // an escaped literal (CommonMark §6.1) and must not open a code region.
+    if (fenceChar == '`') {
+      int numBackslashes = 0;
+      int i = start - 1;
+      while (i >= 0 && _input[i] == '\\') {
+        numBackslashes++;
+        i--;
+      }
+      if (numBackslashes % 2 == 1) {
+        _index = start;
+        return null;
+      }
+    }
+
     // Count consecutive opening characters
     final openStart = _index;
     while (!isDone && peek() == fenceChar) {
@@ -245,10 +260,16 @@ class _Scanner {
       return _scanFencedBlock(start, fenceChar, openCount);
     }
 
-    // Backticks: 3 or more at a line-start position → fenced code block.
-    // Mid-line runs of 3+ backticks fall through to inline-span scanning.
+    // Backticks: 3 or more at a line-start position → fenced code block,
+    // but only when the info string contains no backticks (CommonMark §4.4:
+    // backtick-fence info strings must not include backtick characters).
+    // Mid-line runs, or runs with a backtick-containing info string, fall
+    // through to inline-span scanning.
     if (openCount >= 3 && _isAtLineStart(start)) {
-      return _scanFencedBlock(start, fenceChar, openCount);
+      if (!_infoStringHasBacktick(_index)) {
+        return _scanFencedBlock(start, fenceChar, openCount);
+      }
+      // Info string contains a backtick — not a valid fenced block opener.
     }
 
     // Backticks 1–2 (or 3+ mid-line): inline code span
@@ -352,6 +373,18 @@ class _Scanner {
       (c >= 0x30 && c <= 0x39) || // 0-9
       c == 0x21 ||
       c == 0x3F; // ! ?
+
+  /// Returns true if the region from [pos] to the next newline (or EOF)
+  /// contains a backtick character.  Used to validate backtick-fence info
+  /// strings: CommonMark §4.4 forbids backticks in backtick-fence info strings.
+  bool _infoStringHasBacktick(int pos) {
+    for (int i = pos; i < _input.length; i++) {
+      final c = _input[i];
+      if (c == '\n' || c == '\r') return false;
+      if (c == '`') return true;
+    }
+    return false;
+  }
 
   /// Returns true if [pos] is a valid fenced-block opener position:
   /// either the very start of [_input], or preceded only by up to 3 space

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -274,21 +274,29 @@ class _Scanner {
     }
     if (!isDone) advance(); // consume '\n'
 
-    // Search for a closing fence: a line that begins with >= openCount
-    // of the same fence character
+    // Search for a closing fence: a line that consists of >= openCount fence
+    // characters followed by optional whitespace only (CommonMark §4.4–4.5).
     while (!isDone) {
       final lineStart = _index;
       while (!isDone && peek() == fenceChar) {
         advance();
       }
       final closeCount = _index - lineStart;
-      if (closeCount >= openCount) {
-        // Consume the rest of the closing line
+      // A valid closer must have only optional whitespace after the fence chars.
+      // A line like "```python" has enough backticks but is not a valid closer.
+      bool isValidCloser = closeCount >= openCount;
+      if (isValidCloser) {
         while (!isDone && peek() != '\n') {
+          if (peek() != ' ' && peek() != '\t') {
+            isValidCloser = false;
+            break;
+          }
           advance();
         }
-        if (!isDone) advance(); // consume '\n'
-        return Token(TokenType.markdown, _input.substring(start, _index));
+        if (isValidCloser) {
+          if (!isDone) advance(); // consume '\n'
+          return Token(TokenType.markdown, _input.substring(start, _index));
+        }
       }
       // Not a closing fence — advance to the end of this line
       while (!isDone && peek() != '\n') {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -282,6 +282,13 @@ class _Scanner {
     // Search for a closing fence: a line that consists of >= openCount fence
     // characters followed by optional whitespace only (CommonMark §4.4–4.5).
     while (!isDone) {
+      // CommonMark §4.4–4.5: closing fence may be indented up to 3 spaces.
+      int indent = 0;
+      while (indent < 3 && !isDone && peek() == ' ') {
+        advance();
+        indent++;
+      }
+
       final lineStart = _index;
       while (!isDone && peek() == fenceChar) {
         advance();
@@ -292,7 +299,7 @@ class _Scanner {
       bool isValidCloser = closeCount >= openCount;
       if (isValidCloser) {
         while (!isDone && peek() != '\n') {
-          if (peek() != ' ' && peek() != '\t') {
+          if (peek() != ' ' && peek() != '\t' && peek() != '\r') {
             isValidCloser = false;
             break;
           }

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -1,0 +1,180 @@
+import 'package:smartypants/smartypants.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Markdown inline code protection', () {
+    test('should preserve arrow inside single-backtick span', () {
+      expect(SmartyPants.formatText('`a->b`'), '`a->b`');
+    });
+
+    test('should preserve math symbols inside single-backtick span', () {
+      expect(SmartyPants.formatText('`x != y`'), '`x != y`');
+    });
+
+    test('should preserve dashes inside single-backtick span', () {
+      expect(SmartyPants.formatText('`a--b`'), '`a--b`');
+    });
+
+    test('should preserve quotes inside single-backtick span', () {
+      expect(SmartyPants.formatText('`"hello"`'), '`"hello"`');
+    });
+
+    test('should preserve ellipsis inside single-backtick span', () {
+      expect(SmartyPants.formatText('`a...b`'), '`a...b`');
+    });
+
+    test('should preserve arrow inside double-backtick span', () {
+      expect(SmartyPants.formatText('``a->b``'), '``a->b``');
+    });
+
+    test('should allow single backtick inside double-backtick span', () {
+      expect(SmartyPants.formatText('`` ` ``'), '`` ` ``');
+    });
+
+    test('should transform text outside inline code but protect inside', () {
+      expect(
+        SmartyPants.formatText('"text" `code->here` "more"'),
+        '\u201Ctext\u201D `code->here` \u201Cmore\u201D',
+      );
+    });
+
+    test('should protect multiple inline code spans independently', () {
+      expect(
+        SmartyPants.formatText('`a->b` and `c--d`'),
+        '`a->b` and `c--d`',
+      );
+    });
+
+    test('should transform text between two inline code spans', () {
+      expect(
+        SmartyPants.formatText('`a->b` -- `c->d`'),
+        '`a->b` \u2013 `c->d`',
+      );
+    });
+  });
+
+  group('Markdown fenced code block protection (backtick)', () {
+    test('should preserve content inside triple-backtick fence', () {
+      const input = '```\na->b\n```';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('should preserve content inside fence with language identifier', () {
+      const input = '```dart\na->b\nx != y\n```';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('should transform text before and after fence', () {
+      expect(
+        SmartyPants.formatText(
+          '"before"\n```\na->b\n```\n"after"',
+          config: const SmartyPantsConfig(whitespaceNormalization: false),
+        ),
+        '\u201Cbefore\u201D\n```\na->b\n```\n\u201Cafter\u201D',
+      );
+    });
+
+    test('should handle four-backtick fence closed by four backticks', () {
+      const input = '````\na->b\n````';
+      expect(SmartyPants.formatText(input), input);
+    });
+  });
+
+  group('Markdown fenced code block protection (tilde)', () {
+    test('should preserve content inside triple-tilde fence', () {
+      const input = '~~~\na->b\n~~~';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('should preserve content inside tilde fence with language identifier',
+        () {
+      const input = '~~~python\nx != y\na->b\n~~~';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('should transform text outside tilde fence', () {
+      expect(
+        SmartyPants.formatText(
+          '"before"\n~~~\na->b\n~~~\n"after"',
+          config: const SmartyPantsConfig(whitespaceNormalization: false),
+        ),
+        '\u201Cbefore\u201D\n~~~\na->b\n~~~\n\u201Cafter\u201D',
+      );
+    });
+
+    test('should handle four-tilde fence closed by four tildes', () {
+      const input = '~~~~\na->b\n~~~~';
+      expect(SmartyPants.formatText(input), input);
+    });
+  });
+
+  group('Unclosed region handling', () {
+    test('should treat unclosed inline code as literal and apply transforms',
+        () {
+      // No closing backtick → backtrack, backtick is plain text
+      expect(
+        SmartyPants.formatText('`unclosed -> end'),
+        '`unclosed \u2192 end',
+      );
+    });
+
+    test('should protect to end of input for unclosed backtick fence', () {
+      const input = '```\na->b\nno closing fence';
+      // Everything from ``` to end is protected
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('should protect to end of input for unclosed tilde fence', () {
+      const input = '~~~\nx != y\nno closing fence';
+      expect(SmartyPants.formatText(input), input);
+    });
+  });
+
+  group('Edge cases', () {
+    test('should treat lone backtick as literal text', () {
+      // Single backtick with no match → transform applies to surrounding text
+      expect(SmartyPants.formatText('a ` b -> c'), 'a ` b \u2192 c');
+    });
+
+    test('should treat one or two tildes as literal text', () {
+      expect(SmartyPants.formatText('a ~ b -> c'), 'a ~ b \u2192 c');
+      expect(SmartyPants.formatText('a ~~ b -> c'), 'a ~~ b \u2192 c');
+    });
+
+    test('should handle consecutive independent inline spans', () {
+      // Two spans of different sizes that appear back-to-back in text
+      expect(
+        SmartyPants.formatText('`a->b` ``c--d``'),
+        '`a->b` ``c--d``',
+      );
+    });
+
+    test('should handle empty inline code span', () {
+      expect(SmartyPants.formatText('``'), '``');
+    });
+  });
+
+  group('Mixed HTML and Markdown', () {
+    test('should protect both HTML tags and Markdown inline code', () {
+      expect(
+        SmartyPants.formatText('<b>"text"</b> `a->b`'),
+        '<b>\u201Ctext\u201D</b> `a->b`',
+      );
+    });
+
+    test('should protect HTML code tag and Markdown inline code independently',
+        () {
+      expect(
+        SmartyPants.formatText('<code>a--b</code> `c--d`'),
+        '<code>a--b</code> `c--d`',
+      );
+    });
+
+    test('should transform text between HTML and Markdown regions', () {
+      expect(
+        SmartyPants.formatText('<em>"hi"</em> `a->b` "there"'),
+        '<em>\u201Chi\u201D</em> `a->b` \u201Cthere\u201D',
+      );
+    });
+  });
+}

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -200,6 +200,63 @@ void main() {
     });
   });
 
+  group('Fenced block opener: line-start requirement', () {
+    test('triple-backtick mid-line is treated as inline code span', () {
+      // ```bar``` mid-line → inline span, not a fenced block
+      expect(
+        SmartyPants.formatText('use ```bar``` or "quotes"'),
+        'use ```bar``` or \u201Cquotes\u201D',
+      );
+    });
+
+    test('mid-line triple-backtick span protects its content', () {
+      expect(
+        SmartyPants.formatText('see ```a--b``` here'),
+        'see ```a--b``` here',
+      );
+    });
+
+    test('prose after closed mid-line triple-backtick span is transformed', () {
+      expect(
+        SmartyPants.formatText('x ```code``` "hi"'),
+        'x ```code``` \u201Chi\u201D',
+      );
+    });
+
+    test('unclosed mid-line triple-backtick backtracks and transforms', () {
+      // No matching closer → backtrack, plain text, arrow transformed
+      expect(
+        SmartyPants.formatText('x ```a->b'),
+        'x ```a\u2192b',
+      );
+    });
+
+    test('triple-backtick after 4-space indent becomes inline span', () {
+      // 4 spaces exceeds CommonMark indent limit; not a fenced block opener.
+      // Falls through to inline span: content is protected (arrow unchanged),
+      // post-span prose is transformed (smart quote applied), and leading
+      // whitespace is collapsed by whitespace normalization.
+      expect(
+        SmartyPants.formatText('    ```\na->b\n```\n"hi"'),
+        ' ```\na->b\n``` \u201Chi\u201D',
+      );
+    });
+
+    test('triple-tilde mid-line backtracks to plain text', () {
+      expect(
+        SmartyPants.formatText('x ~~~a->b'),
+        'x ~~~a\u2192b',
+      );
+    });
+
+    test('line-start triple-backtick fence still works normally', () {
+      expect(
+        SmartyPants.formatText('```\na->b\n```\n"hi"'),
+        '```\na->b\n```\n\u201Chi\u201D',
+      );
+    });
+  });
+
   group('Fenced block closer: indented closing fence', () {
     test('1-space indent before closing fence is accepted', () {
       const input = '```\na -> b\n ```\nafter';

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -406,4 +406,49 @@ void main() {
       );
     });
   });
+
+  group('Escaped opener followed by unescaped backtick (P2)', () {
+    // When scanMarkdown() rejects a backtick run because the *first* backtick
+    // is escaped, only that one backtick should be consumed as literal text.
+    // The immediately following unescaped backtick(s) must still be eligible
+    // to open their own inline code span.
+
+    test('tokenize: escaped opener leaves next backtick as a code-span opener',
+        () {
+      // Input: \``code`
+      // \` → escaped literal backtick (text)
+      // `code` → inline code span (markdown)
+      expect(tokenize(r'\``code`'), [
+        Token(TokenType.text, r'\`'),
+        Token(TokenType.markdown, '`code`'),
+      ]);
+    });
+
+    test('arrow inside span preceded by escaped backtick is protected', () {
+      // \` is a literal backtick; `a->b` is a code span — arrow stays as ->.
+      expect(SmartyPants.formatText(r'\``a->b`'), r'\``a->b`');
+    });
+
+    test('without following span, escaped backtick prose arrow is transformed',
+        () {
+      // \`a->b` — no valid code span forms; arrow is in plain text → →.
+      expect(SmartyPants.formatText(r'\`a->b`'), contains('\u2192'));
+    });
+
+    test('double-escaped opener (even backslashes) consumes whole run', () {
+      // \\``code` — two backslashes cancel out, backtick run is NOT escaped.
+      // openCount=2, no double-backtick closer → whole run consumed as text.
+      // Arrow in prose IS transformed.
+      expect(SmartyPants.formatText(r'\\``a->b`'), contains('\u2192'));
+    });
+
+    test('triple-backslash escaped opener still leaves next backtick free', () {
+      // \\\``code` — three backslashes: first pair cancel, third escapes the
+      // first backtick.  Second backtick is unescaped → opens code span.
+      expect(tokenize(r'\\\``code`'), [
+        Token(TokenType.text, r'\\\`'),
+        Token(TokenType.markdown, '`code`'),
+      ]);
+    });
+  });
 }

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -336,4 +336,74 @@ void main() {
       );
     });
   });
+
+  group('Backtick fence opener: info string validation (P1)', () {
+    // CommonMark §4.4: backtick-fence info strings must not contain backticks.
+    // If the info string has a backtick, the opener is invalid and must fall
+    // through to inline-span matching so prose after the span is transformed.
+
+    test('info string with backtick is not a valid fenced block opener', () {
+      // ````code``` "after"` — info string "code```" contains backticks.
+      // Falls to inline span (4-backtick opener looking for 4-backtick closer).
+      // No 4-backtick closer exists → backtracks → prose is transformed.
+      expect(
+        SmartyPants.formatText('````code``` "after"'),
+        contains('\u201C'), // opening " in "after" must be smart-quoted
+      );
+    });
+
+    test('info string without backtick opens a valid fenced block', () {
+      // ```python\n…\n``` — "python" has no backtick → fenced block protected.
+      expect(
+        SmartyPants.formatText('```python\na->b\n```\n"hi"'),
+        '```python\na->b\n```\n\u201Chi\u201D',
+      );
+    });
+
+    test('plain fence with no info string still opens a fenced block', () {
+      expect(
+        SmartyPants.formatText('```\na->b\n```\n"hi"'),
+        '```\na->b\n```\n\u201Chi\u201D',
+      );
+    });
+  });
+
+  group('Escaped backtick handling (P2)', () {
+    // CommonMark §6.1: a backslash before a backtick escapes it, making it a
+    // plain-text literal rather than a code-span delimiter.
+
+    test('backtick preceded by backslash is not a code span opener', () {
+      // \`a->b` — the opening backtick is escaped; no code span forms.
+      // Arrow must be transformed.
+      expect(
+        SmartyPants.formatText(r'\`a->b`'),
+        contains('\u2192'),
+      );
+    });
+
+    test('escaped backtick does not swallow arrow in surrounding prose', () {
+      // Without the fix, \`a->b` would be mis-parsed as a code span,
+      // protecting -> from transformation.
+      final result = SmartyPants.formatText(r'\`a->b`');
+      expect(result, isNot(contains('->')));
+    });
+
+    test('double-backslash before backtick is not an escape (even count)', () {
+      // \\`a->b` — two backslashes escape each other, leaving ` as a real
+      // opener. Content is protected; arrow must NOT be transformed.
+      expect(
+        SmartyPants.formatText(r'\\`a->b`'),
+        isNot(contains('\u2192')),
+      );
+    });
+
+    test('triple-backslash before backtick is an escape (odd count)', () {
+      // \\\`a->b` — three backslashes: the third is escaped by none, leaving
+      // the backtick escaped. Arrow must be transformed.
+      expect(
+        SmartyPants.formatText(r'\\\`a->b`'),
+        contains('\u2192'),
+      );
+    });
+  });
 }

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -200,6 +200,62 @@ void main() {
     });
   });
 
+  group('Fenced block closer: indented closing fence', () {
+    test('1-space indent before closing fence is accepted', () {
+      const input = '```\na -> b\n ```\nafter';
+      expect(SmartyPants.formatText(input), '```\na -> b\n ```\nafter');
+    });
+
+    test('2-space indent before closing fence is accepted', () {
+      const input = '```\na -> b\n  ```\nafter';
+      expect(SmartyPants.formatText(input), '```\na -> b\n  ```\nafter');
+    });
+
+    test('3-space indent before closing fence is accepted', () {
+      const input = '```\na -> b\n   ```\nafter';
+      expect(SmartyPants.formatText(input), '```\na -> b\n   ```\nafter');
+    });
+
+    test('4-space indent before closing fence is not accepted', () {
+      // 4-space indent exceeds CommonMark limit; block stays open to end
+      const input = '```\na -> b\n    ```';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('prose after indented closer is transformed', () {
+      expect(
+        SmartyPants.formatText('```\ncode\n ```\n"hello"'),
+        '```\ncode\n ```\n\u201Chello\u201D',
+      );
+    });
+  });
+
+  group('Fenced block closer: CRLF line endings', () {
+    test('closing fence with CRLF is accepted (backtick)', () {
+      const input = '```\r\na -> b\r\n```\r\nafter';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('closing fence with CRLF is accepted (tilde)', () {
+      const input = '~~~\r\na -> b\r\n~~~\r\nafter';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    test('prose after CRLF-terminated closer is transformed', () {
+      expect(
+        SmartyPants.formatText('```\r\ncode\r\n```\r\n"hello"'),
+        '```\r\ncode\r\n```\r\n\u201Chello\u201D',
+      );
+    });
+
+    test('CRLF closer with trailing spaces is accepted', () {
+      expect(
+        SmartyPants.formatText('```\r\ncode\r\n```  \r\n"hi"'),
+        '```\r\ncode\r\n```  \r\n\u201Chi\u201D',
+      );
+    });
+  });
+
   group('Mixed HTML and Markdown', () {
     test('should protect both HTML tags and Markdown inline code', () {
       expect(

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -78,6 +78,24 @@ void main() {
       const input = '````\na->b\n````';
       expect(SmartyPants.formatText(input), input);
     });
+
+    test('closing fence with trailing whitespace is still a valid closer', () {
+      // A line of exactly openCount backticks + trailing spaces/tabs closes the
+      // block (CommonMark §4.4).
+      const input = '```\na->b\n```   ';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    // Regression: a line like "```python" starts with >= openCount backticks
+    // but has non-whitespace content after them — it must NOT close the fence.
+    test(
+        'line with fence chars + non-whitespace content does not close the block',
+        () {
+      // The inner "```python" line has 3 backticks but a non-whitespace tail;
+      // it must be treated as code content, not as a closer.
+      const input = '```\n```python\na != b\n```';
+      expect(SmartyPants.formatText(input), input);
+    });
   });
 
   group('Markdown fenced code block protection (tilde)', () {
@@ -104,6 +122,13 @@ void main() {
 
     test('should handle four-tilde fence closed by four tildes', () {
       const input = '~~~~\na->b\n~~~~';
+      expect(SmartyPants.formatText(input), input);
+    });
+
+    // Regression: "~~~python" inside a tilde fence must not close the block.
+    test('tilde line with non-whitespace tail does not close the fenced block',
+        () {
+      const input = '~~~\n~~~python\na != b\n~~~';
       expect(SmartyPants.formatText(input), input);
     });
   });

--- a/test/smartypants_markdown_test.dart
+++ b/test/smartypants_markdown_test.dart
@@ -143,6 +143,27 @@ void main() {
       );
     });
 
+    // Regression: when a double-backtick opener has no matching double-backtick
+    // closer, scanMarkdown() backtracks.  The entire run (both backticks) must
+    // be consumed atomically as plain text.  If only one backtick were consumed,
+    // the second would be retried as a single-backtick opener and could
+    // spuriously match the lone closer at the end, masking the content as code.
+    test(
+        'double-backtick opener with only single-backtick closer applies transforms',
+        () {
+      // ``a->b` — double-backtick has no closer; single-backtick at end is
+      // also unmatched.  Everything is plain text → arrow must be transformed.
+      expect(SmartyPants.formatText('``a->b`'), '``a\u2192b`');
+    });
+
+    test(
+        'single-backtick opener with only double-backtick closer applies transforms',
+        () {
+      // `a->b`` — single-backtick has no single-backtick closer (the `` at the
+      // end has count 2 ≠ 1).  Plain text → arrow must be transformed.
+      expect(SmartyPants.formatText('`a->b``'), '`a\u2192b``');
+    });
+
     test('should protect to end of input for unclosed backtick fence', () {
       const input = '```\na->b\nno closing fence';
       // Everything from ``` to end is protected


### PR DESCRIPTION
## Summary

Extend the tokenizer to recognize Markdown inline code spans and fenced code blocks, and exclude their content from all typographic transformations — no configuration required.

## Background / Motivation

SmartyPants is commonly applied to Markdown content (editors, static site generators, documentation tools). Until now, text inside inline code (`` `a->b` ``) and fenced code blocks (` ``` `) was subject to the same typographic rules as regular prose, silently corrupting literal code.

For example:

```markdown
Use `a->b` to indicate direction.
```

```
x != y
```

would incorrectly produce `` `a→b` `` and `x ≠ y` inside the code regions. Developers relying on smartypants for Markdown rendering had no safe way to prevent this without pre-stripping code blocks themselves.

## Related Issues

- Closes #

## Changes

- **`TokenType.markdown`** — new enum value for code-region tokens; masked with the same U+FFFC placeholder mechanism used for HTML, so their content is never passed through `_applyTransformations`.
- **`tokenize()`** — detects `` ` `` and `~` as additional trigger characters and delegates to `scanMarkdown()`.
- **`_Scanner.scanMarkdown()`** — character-by-character scanner that handles single/double-backtick inline spans, triple-or-more backtick/tilde fenced blocks, and graceful fallback for unclosed spans.
- **`_Scanner._scanFencedBlock()`** — shared helper for backtick and tilde fences; closes on the first line starting with ≥ `openCount` fence characters, or protects to end of input if unclosed.
- **`smartypants_base.dart`** — masking condition extended to include `TokenType.markdown` alongside `TokenType.html`.
- **`example/lib/example_data.dart`** — new "Markdown Support" category with illustrative examples.
- **`benchmark/smartypants_benchmark.dart`** — benchmark cases for light and heavy Markdown inputs.

Markdown protection is always active; no API flag is needed because backticks and tildes are essentially never used outside of code contexts in prose.

## Test Plan

- Commands run:
    - `dart test`
    - `cd example && flutter test`
- Notes:
    - 28 new tests in `test/smartypants_markdown_test.dart` covering inline code, backtick fences, tilde fences, unclosed regions, edge cases, and mixed HTML + Markdown.
    - All 148 tests (existing + new) pass with no regressions.

## Documentation (If Needed)

- Dartdoc on `TokenType`, `tokenize()`, `scanMarkdown()`, and `_scanFencedBlock()` updated to reflect Markdown token support.
- Example app "Markdown Support" category demonstrates the protection in action.

## Breaking Change (If Any)

- `TokenType` gains a new `markdown` value. Code that exhaustively switches on `TokenType` without a default case will need a new branch.
- Migration notes:
    - Add a `markdown` case (or a default) to any exhaustive `switch` on `TokenType`. Treat it the same as `html` — protected content that should not be modified.
