### PR TITLE
chore: add code coverage, fuzz, stress, and Flutter integration tests (#33)

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,8 +30,17 @@ jobs:
       - name: Verify documentation
         run: dart doc --dry-run
 
-      - name: Run tests
-        run: dart test
+      - name: Run tests with coverage
+        run: dart test --coverage=coverage
+
+      - name: Format coverage to lcov
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage/lcov.info
+          flags: unittests
 
       - name: Install example dependencies
         working-directory: ./example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # smartypants
 
-![Pub Version](https://img.shields.io/pub/v/smartypants) ![GitHub License](https://img.shields.io/github/license/eunice-hong/smartypants)
+![Pub Version](https://img.shields.io/pub/v/smartypants) ![GitHub License](https://img.shields.io/github/license/eunice-hong/smartypants) [![codecov](https://codecov.io/gh/eunice-hong/smartypants/branch/main/graph/badge.svg)](https://codecov.io/gh/eunice-hong/smartypants)
 
 A Dart package that implements SmartyPants text formatting. This package helps convert plain text into a more typographically correct format by replacing certain characters and symbols with their "smart" counterparts.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -225,4 +225,68 @@ void main() {
     // Both smart quotes and CJK ellipsis should be transformed
     expect(find.text('\u201cHello\u201d 기다려주세요…'), findsOneWidget);
   });
+
+  // ── SmartypantsFormatter Edge Case Tests ─────────────────────────────────
+
+  test('SmartypantsFormatter handles non-BMP Unicode without crash', () {
+    final formatter = SmartypantsFormatter();
+
+    // Non-BMP characters (emoji U+1F600) require surrogate pairs in UTF-16.
+    // The formatter must not crash when the cursor lands inside a surrogate pair.
+    const newValue = TextEditingValue(
+      text: '"Hello \u{1F600}"',
+      selection: TextSelection.collapsed(offset: 9),
+    );
+    const oldValue = TextEditingValue(text: '');
+
+    expect(
+      () => formatter.formatEditUpdate(oldValue, newValue),
+      returnsNormally,
+    );
+  });
+
+  test('SmartypantsFormatter preserves cursor position after transformation',
+      () {
+    final formatter = SmartypantsFormatter();
+
+    // '"Hello"' (7 chars) transforms to '\u201cHello\u201d' (7 chars).
+    // Cursor placed at end (offset 7) should stay at end after formatting.
+    const oldValue = TextEditingValue(text: '');
+    const newValue = TextEditingValue(
+      text: '"Hello"',
+      selection: TextSelection.collapsed(offset: 7),
+    );
+
+    final result = formatter.formatEditUpdate(oldValue, newValue);
+
+    expect(result.text, '\u201cHello\u201d');
+    expect(
+      result.selection.baseOffset,
+      result.text.length,
+      reason: 'Cursor should be at the end of the transformed text',
+    );
+  });
+
+  test('SmartypantsFormatter handles rapid sequential edits', () {
+    final formatter = SmartypantsFormatter();
+    var current = const TextEditingValue(text: '');
+
+    // Simulate typing '"Hello" -- ' character by character
+    final chars = ['"', 'H', 'e', 'l', 'l', 'o', '"', ' ', '-', '-', ' '];
+    for (final char in chars) {
+      final next = TextEditingValue(
+        text: current.text + char,
+        selection: TextSelection.collapsed(
+          offset: current.text.length + 1,
+        ),
+      );
+      expect(
+        () => current = formatter.formatEditUpdate(current, next),
+        returnsNormally,
+        reason: 'Should not throw when appending "$char" to "${current.text}"',
+      );
+    }
+
+    expect(current.text, isNotEmpty);
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,4 @@ dependencies:
 dev_dependencies:
   lints: ^5.0.0
   test: ^1.24.0
+  coverage: ^1.6.0

--- a/test/smartypants_fuzz_test.dart
+++ b/test/smartypants_fuzz_test.dart
@@ -1,0 +1,67 @@
+import 'dart:math';
+import 'package:test/test.dart';
+import 'package:smartypants/smartypants.dart';
+
+// Characters that are used internally as sentinels by the smartypants library.
+// U+E000, U+E001, U+E002 are private-use-area markers; U+FFFC is the object
+// replacement character used during HTML tag masking.
+const _sentinelChars = ['\uE000', '\uE001', '\uE002', '\uFFFC'];
+
+String _randomString(
+  Random rng,
+  int maxLength, {
+  required bool includeSpecial,
+}) {
+  final length = rng.nextInt(maxLength) + 1;
+  final buffer = StringBuffer();
+  for (int i = 0; i < length; i++) {
+    if (includeSpecial && rng.nextInt(10) == 0) {
+      // ~10% chance to insert a sentinel or private-use character
+      buffer.write(_sentinelChars[rng.nextInt(_sentinelChars.length)]);
+    } else {
+      // Printable ASCII range (0x20–0x7E)
+      buffer.writeCharCode(rng.nextInt(0x7F - 0x20) + 0x20);
+    }
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('Fuzz: formatText never throws', () {
+    // Fixed seed for reproducibility across runs.
+    final rng = Random(42);
+
+    test('random ASCII input does not throw', () {
+      for (int i = 0; i < 10000; i++) {
+        final input = _randomString(rng, 100, includeSpecial: false);
+        expect(
+          () => SmartyPants.formatText(input),
+          returnsNormally,
+          reason: 'Iteration $i, input: $input',
+        );
+      }
+    });
+
+    test(
+        'input with private-use-area chars (U+E000–U+E002, U+FFFC) does not throw',
+        () {
+      for (int i = 0; i < 5000; i++) {
+        final input = _randomString(rng, 50, includeSpecial: true);
+        expect(
+          () => SmartyPants.formatText(input),
+          returnsNormally,
+          reason: 'Iteration $i, input: $input',
+        );
+      }
+    });
+
+    test('idempotency: formatText(formatText(x)) == formatText(x)', () {
+      for (int i = 0; i < 1000; i++) {
+        final input = _randomString(rng, 80, includeSpecial: false);
+        final once = SmartyPants.formatText(input);
+        final twice = SmartyPants.formatText(once);
+        expect(twice, equals(once), reason: 'Input: $input');
+      }
+    });
+  });
+}

--- a/test/smartypants_stress_test.dart
+++ b/test/smartypants_stress_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+import 'package:smartypants/smartypants.dart';
+
+void main() {
+  group('Stress tests', () {
+    test('10KB input completes within 100ms', () {
+      final input = '"Hello" -- World... ' * 500;
+      final sw = Stopwatch()..start();
+      SmartyPants.formatText(input);
+      sw.stop();
+      expect(
+        sw.elapsedMilliseconds,
+        lessThan(100),
+        reason: 'Took ${sw.elapsedMilliseconds}ms for ~10KB input',
+      );
+    });
+
+    test('100KB input completes within 1000ms', () {
+      final input = '"Hello" -- World... ' * 5000;
+      final sw = Stopwatch()..start();
+      SmartyPants.formatText(input);
+      sw.stop();
+      expect(
+        sw.elapsedMilliseconds,
+        lessThan(1000),
+        reason: 'Took ${sw.elapsedMilliseconds}ms for ~100KB input',
+      );
+    });
+
+    test('HTML-heavy input (1000 tags) completes within 200ms', () {
+      final input = '<p>"Hello" -- World...</p>\n' * 200;
+      final sw = Stopwatch()..start();
+      SmartyPants.formatText(input);
+      sw.stop();
+      expect(
+        sw.elapsedMilliseconds,
+        lessThan(200),
+        reason: 'Took ${sw.elapsedMilliseconds}ms for HTML-heavy input',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds four missing testing infrastructure capabilities: code coverage tracking via Codecov, fuzz testing for sentinel character edge cases, stress tests for performance regression detection, and additional Flutter `SmartypantsFormatter` integration tests.

## Background / Motivation

The existing test suite covers functional correctness but lacks coverage quantification, making untested code paths invisible across PRs. The tokenizer's private-use-area sentinel mechanism (U+E000–U+E002, U+FFFC) is fragile under adversarial or colliding inputs that manual tests cannot exhaustively explore. There is also no performance baseline and no Flutter edge-case coverage for non-BMP Unicode, cursor preservation, or rapid sequential edits.

## Related Issues

- Closes #33

## Changes

- **`pubspec.yaml`**: Add `coverage: ^1.6.0` dev_dependency
- **`.github/workflows/pr_check.yml`**: Replace `dart test` with `dart test --coverage=coverage`; add lcov formatting and Codecov upload steps
- **`codecov.yml`** (new): Set 80% project coverage target with 2% regression threshold
- **`README.md`**: Add Codecov badge
- **`test/smartypants_fuzz_test.dart`** (new):
  - 10,000-iteration random ASCII fuzz test (fixed seed 42 for reproducibility)
  - 5,000-iteration fuzz test injecting private-use-area chars (U+E000–U+E002, U+FFFC)
  - 1,000-iteration idempotency property test: `formatText(formatText(x)) == formatText(x)`
- **`test/smartypants_stress_test.dart`** (new):
  - 10 KB input completes within 100 ms
  - 100 KB input completes within 1000 ms
  - HTML-heavy input (1,000 tags) completes within 200 ms
- **`example/test/widget_test.dart`**: Add three `SmartypantsFormatter` edge-case unit tests:
  - Non-BMP Unicode (emoji U+1F600) does not crash
  - Cursor position is preserved at end of text after transformation
  - Rapid sequential character-by-character edits do not throw

## Test Plan

- Commands run:
    - `dart test` (full suite — existing + fuzz + stress)
    - `dart test test/smartypants_fuzz_test.dart`
    - `dart test test/smartypants_stress_test.dart`
    - `cd example && flutter test`
- Notes:
    - Fuzz tests use a fixed seed (42), so they are fully deterministic and reproducible in CI.
    - Stress test thresholds are intentionally generous to avoid flaky CI failures; they serve as regression guards, not precise benchmarks.

## Documentation (If Needed)

- Added Codecov badge to `README.md`

## Breaking Change (If Any)

- Migration notes:
    - None. This PR adds tests and CI configuration only; no existing behavior is changed.
